### PR TITLE
Fix attention bug in nd sbp

### DIFF
--- a/libai/layers/attention.py
+++ b/libai/layers/attention.py
@@ -16,9 +16,7 @@
 import math
 import oneflow as flow
 from oneflow import nn
-import oneflow.nn.init as init
 
-from libai.utils import distributed as dist
 from .linear import Linear
 
 
@@ -38,27 +36,39 @@ class MultiheadAttention(nn.Module):
         apply_query_key_layer_scaling: if `true`, scaling the attention score by layer index. Default: ``False``.
         layer_idx: A layer_idx sign which determines the placements. It will be used in pipeline parallelism. Default: ``0``.
     """
-    def __init__(self, hidden_size, num_attention_heads, is_cross_attention=False,
-                 attention_dropout_prob=0., output_dropout_prob=0., 
-                 init_method=init.xavier_normal_, output_layer_init_method=None, 
-                 bias_dropout_fusion=False, scale_mask_softmax_fusion=False, 
-                 apply_query_key_layer_scaling=False,
-                 *, layer_idx=0):
+
+    def __init__(
+        self,
+        hidden_size,
+        num_attention_heads,
+        is_cross_attention=False,
+        attention_dropout_prob=0.0,
+        output_dropout_prob=0.0,
+        init_method=nn.init.xavier_normal_,
+        output_layer_init_method=None,
+        bias_dropout_fusion=False,
+        scale_mask_softmax_fusion=False,
+        apply_query_key_layer_scaling=False,
+        *,
+        layer_idx=0
+    ):
         super().__init__()
         self.hidden_size = hidden_size
         if output_layer_init_method is None:
             output_layer_init_method = init_method
 
-        assert hidden_size % num_attention_heads == 0, "hidden_size must be divisible by num_attention_heads."
+        assert (
+            hidden_size % num_attention_heads == 0
+        ), "hidden_size must be divisible by num_attention_heads."
 
         self.num_heads = num_attention_heads
         self.head_size = hidden_size // num_attention_heads
-        
-        self.dropout = flow.nn.Dropout(p=attention_dropout_prob)
+
+        self.dropout = nn.Dropout(p=attention_dropout_prob)
         self.norm_factor = 1.0 / math.sqrt(float(self.head_size))
         if apply_query_key_layer_scaling:
-            self.norm_factor /=  float(layer_idx + 1)
-        
+            self.norm_factor /= float(layer_idx + 1)
+
         self.is_cross_attention = is_cross_attention
         self.scale_mask_softmax_fusion = scale_mask_softmax_fusion
         self.bias_dropout_fusion = bias_dropout_fusion
@@ -66,26 +76,49 @@ class MultiheadAttention(nn.Module):
         if self.bias_dropout_fusion:
             self.output_dropout_prob = output_dropout_prob
         else:
-            self.output_dropout = flow.nn.Dropout(p=output_dropout_prob)
+            self.output_dropout = nn.Dropout(p=output_dropout_prob)
 
         if self.is_cross_attention:
-            self.query = Linear(self.hidden_size, self.hidden_size, parallel='col', 
-                                init_method=init_method, 
-                                layer_idx=layer_idx)
-            self.key_value = Linear(self.hidden_size, self.hidden_size * 2, parallel='col', 
-                                    init_method=init_method, 
-                                    layer_idx=layer_idx)
+            self.query = Linear(
+                self.hidden_size,
+                self.hidden_size,
+                parallel="col",
+                init_method=init_method,
+                layer_idx=layer_idx,
+            )
+            self.key_value = Linear(
+                self.hidden_size,
+                self.hidden_size * 2,
+                parallel="col",
+                init_method=init_method,
+                layer_idx=layer_idx,
+            )
         else:
-            self.query_key_value = Linear(self.hidden_size, self.hidden_size * 3, parallel='col', 
-                                          init_method=init_method, 
-                                          layer_idx=layer_idx)
+            self.query_key_value = Linear(
+                self.hidden_size,
+                self.hidden_size * 3,
+                parallel="col",
+                init_method=init_method,
+                layer_idx=layer_idx,
+            )
 
-        self.dense = Linear(self.hidden_size, self.hidden_size, parallel='row', 
-                            init_method=output_layer_init_method, 
-                            skip_bias_add=self.bias_dropout_fusion,
-                            layer_idx=layer_idx)
+        self.dense = Linear(
+            self.hidden_size,
+            self.hidden_size,
+            parallel="row",
+            init_method=output_layer_init_method,
+            skip_bias_add=self.bias_dropout_fusion,
+            layer_idx=layer_idx,
+        )
 
-    def forward(self, hidden_states, encoder_states=None, attention_mask=None, past_key_value=None, use_cache=False):
+    def forward(
+        self,
+        hidden_states,
+        encoder_states=None,
+        attention_mask=None,
+        past_key_value=None,
+        use_cache=False,
+    ):
         """ hidden_states: [tgt_len, bsz, hidden_size]. We adopted seq_len first setting for faster operation.
             encoder_states: [src_len, bsz, hidden_size].
             attention_mask: [bsz, 1, tgt_len, src_len], it should be the combination of padding mask and casual mask.
@@ -100,12 +133,16 @@ class MultiheadAttention(nn.Module):
         # attention_mask: [S(0), B]
 
         if encoder_states is not None:
-            encoder_states = encoder_states.to_consistent(placement=hidden_states.placement)
-        
-        if attention_mask is not None:
-            attention_mask = attention_mask.to_consistent(placement=hidden_states.placement)
+            encoder_states = encoder_states.to_consistent(
+                placement=hidden_states.placement
+            )
 
-        tgt_len, bsz = hidden_states.size()[:-2]
+        if attention_mask is not None:
+            attention_mask = attention_mask.to_consistent(
+                placement=hidden_states.placement
+            )
+
+        bsz, tgt_len = hidden_states.size()[:2]
 
         if self.is_cross_attention:
             # if it is cross attention, key and value should be calculated only once, and the result can be reused.
@@ -114,56 +151,79 @@ class MultiheadAttention(nn.Module):
                 key, value = past_key_value
             elif encoder_states is not None:
                 key_value = self.key_value(encoder_states)
-                key_value = query_key_value.view(-1, bsz, self.num_heads, 2 * self.head_size)
-                key, value = flow.split(key_value, 2, dim=-1)            # [src_len, bsz, num_heads, head_size]
+                key_value = key_value.view(-1, bsz, self.num_heads, 2 * self.head_size)
+                key, value = flow.split(
+                    key_value, 2, dim=-1
+                )  # [src_len, bsz, num_heads, head_size]
             else:
-                raise ValueError("past_key_value and encoder_states cannot be None at the same time.")
+                raise ValueError(
+                    "past_key_value and encoder_states cannot be None at the same time."
+                )
         else:
             # if it is self attention, query, key, and value are all obtained from hidden_states.
-            # when in the inference phase of an incremental decoder, hidden_states is the last-added state, 
+            # when in the inference phase of an incremental decoder, hidden_states is the last-added state,
             # the full key and value could be obtained by concatenating with past_key_value.
             query_key_value = self.query_key_value(hidden_states)
-            query_key_value = query_key_value.view(-1, bsz, self.num_heads, 3 * self.head_size)
-            query, key, value = flow.split(query_key_value, 3, dim=-1)   # [tgt_len, bsz, num_heads, head_size]
+            new_qkv_shape = query_key_value.size()[:-1] + (
+                self.num_heads,
+                3 * self.head_size,
+            )
+            query_key_value = query_key_value.view(*new_qkv_shape)
+            query_key_value = query_key_value.permute(0, 2, 1, 3)
+            # TODO(l1aoxingyu): Change dim to -1
+            query, key, value = flow.chunk(
+                query_key_value, chunks=3, dim=query_key_value.ndim - 1
+            )
             if past_key_value is not None:
                 past_key, past_value = past_key_value
                 key = flow.cat((past_key.type_as(key), key), dim=0)
                 value = flow.cat((past_value.type_as(value), value), dim=0)
-        
-        # query, key, value: [S(1), S(2)], shape: [seq_length, bsz, num_heads, head_size]
+
+        # query, key, value: [S(0), S(1)], shape: [bsz, num_heads, seq_length, head_size]
         if use_cache:
             past_key_value = (key, value)
 
-        # [S(0), S(1)]
-        query = query.permute(1, 2, 0, 3)       # [bsz, num_heads, tgt_len, head_size]
-        key = key.permute(1, 2, 0, 3)           # [bsz, num_heads, src_len, head_size]
-        value = value.permute(1, 2, 0, 3)       # [bsz, num_heads, src_len, head_size]
+        # [bsz, num_heads, tgt_len, src_len] with [S(0), S(1)]
+        attention_scores = flow.matmul(
+            query, key, transpose_b=True, alpha=self.norm_factor
+        )
 
-        # [S(0), S(1)] x [S(0), S(1)] = [S(0), S(1)]
-        attention_scores = flow.matmul(query, key, transpose_b=True, alpha=self.norm_factor)    # [bsz, num_heads, tgt_len, src_len]
-        
         # [S(0), S(1)] x [S(0), B] = [S(0), S(1)]
         if attention_mask is not None:
             if self.scale_mask_softmax_fusion:
-                attention_weights = flow._C.fused_scale_mask_softmax(attention_scores, attention_mask, fill_value=-10000.0)
+                attention_weights = flow._C.fused_scale_mask_softmax(
+                    attention_scores, attention_mask, fill_value=-10000.0
+                )
             else:
-                attention_scores = flow.mul(attention_scores, attention_mask) - 10000.0 * (1.0 - attention_mask)
+                attention_scores = flow.mul(attention_scores, attention_mask)
+                # TODO(l1aoxingyu): graph will occur `where_scalar` errors when using `masked_fill`
+                # attention_scores = attention_scores.masked_fill(attention_mask, -10000.0)
+                attention_scores *= 1 - attention_mask
+                attention_scores += attention_mask * -10000.0
                 attention_weights = flow.softmax(attention_scores, dim=-1)
         else:
             attention_weights = flow.softmax(attention_scores, dim=-1)
 
-        attention_weights = self.dropout(attention_weights)      # [bsz, num_heads, tgt_len, src_len]
+        # [bsz, num_heads, tgt_len, src_len]
+        attention_weights = self.dropout(attention_weights)
 
-        # [S(0), S(1)] x [S(0), S(1)] = [S(0), S(1)]
-        context = flow.matmul(attention_weights, value)                           # [bsz, num_heads, tgt_len, head_size]
-        context = context.transpose(0, 1).view(tgt_len, bsz, self.hidden_size)    # [tgt_len, bsz, hidden_size], sbp: [S(1), S(2)]
-        
-        # [S(1), S(2)] x [B, S(0)] = [S(1), P] -> [S(1), B]
+        # Context shape: [bsz, num_heads, tgt_len, head_size] with [S(0), S(1)]
+        context = flow.matmul(attention_weights, value)
+        # Change shape: [bsz, num_heads, tgt_len, head_size] -> [bsz, tgt_len, num_heads, head_size]
+        context = context.transpose(1, 2)
+
+        # Concat multi-head results from [bsz, tgt_len, num_heads, head_size] -> [bsz, tgt_len, num_heads * head_size]
+        # SBP sign: [S(0), S(2)]
+        context = context.view(bsz, tgt_len, self.hidden_size)
+
+        # [S(0), S(2)] x [B, S(0)] = [S(0), P] -> [S(0), B]
         output = self.dense(context)
 
         if self.bias_dropout_fusion:
             output, bias = output
-            output = flow._C.fused_bias_add_dropout(output, bias, p=self.output_dropout_prob, axis=output.ndim - 1)
+            output = flow._C.fused_bias_add_dropout(
+                output, bias, p=self.output_dropout_prob, axis=output.ndim - 1
+            )
         else:
             output = self.output_dropout(output)
 
@@ -176,4 +236,3 @@ class MultiheadAttention(nn.Module):
         return "hidden_size={}, num_heads={}, is_cross_attention={}".format(
             self.hidden_size, self.num_heads, self.is_cross_attention,
         )
-

--- a/libai/layers/embedding.py
+++ b/libai/layers/embedding.py
@@ -20,6 +20,7 @@ from oneflow.nn import init
 
 from libai.utils import distributed as dist
 
+
 class Embedding(nn.Module):
     """Construct the trainable embedding module, which does not support parallelization.
     This can be used for positional embedding and token type embedding.
@@ -74,15 +75,14 @@ class Embedding(nn.Module):
         #   embed    pos_ids       pos_embed
         input_embeds = flow._C.gather(self.weight, input_ids, axis=0)
         return input_embeds
-    
+
     def _fill_padding_idx_with_zero(self) -> None:
         if self.padding_idx is not None:
             with flow.no_grad():
                 self.weight[self.padding_idx] = flow.zeros(
                     self.embedding_dim,
                     placement=dist.get_layer_placement(0),
-                    sbp=dist.get_nd_sbp(
-                        [flow.sbp.broadcast, flow.sbp.broadcast]),
+                    sbp=dist.get_nd_sbp([flow.sbp.broadcast, flow.sbp.broadcast]),
                 )
 
     def extra_repr(self) -> str:

--- a/libai/layers/layer_norm.py
+++ b/libai/layers/layer_norm.py
@@ -74,7 +74,7 @@ class LayerNorm(nn.Module):
                 self.bias,
                 begin_norm_axis=begin_norm_axis,
                 begin_params_axis=begin_params_axis,
-                epsilon=self.epsilon,
+                epsilon=self.eps,
             )
         else:
             y = flow._C.layer_norm(

--- a/libai/layers/linear.py
+++ b/libai/layers/linear.py
@@ -108,7 +108,7 @@ class Linear1D(nn.Module):
             # if the last dim of weight sbp sign is S(1), the last dim of x sbp sign must be B.
             if self.weight.sbp[-1] == flow.sbp.split(1):
                 x_sbp = x.sbp[:-1] + (flow.sbp.broadcast,)
-                x = x.to_consistent(sbp=x_sbp)        
+                x = x.to_consistent(sbp=x_sbp)
 
             # x.grad sbp must be x.sbp, otherwise backward pass cannot be performed correctly.
             x = x.to_consistent(grad_sbp=x.sbp)
@@ -124,7 +124,7 @@ class Linear1D(nn.Module):
                 out_sbp = x.sbp[:-1] + (flow.sbp.broadcast,)
             else:
                 out_sbp = x.sbp
-            
+
             x = flow._C.matmul(x, self.weight)
             # change x.sbp for followup forward pass.
             x = x.to_consistent(sbp=out_sbp)


### PR DESCRIPTION
在用 libai.layers 中的模块进行 bert nd sbp 重构，修复训练中出现的一些 bug

主要的问题是本来计划将 seq 和 batch 维度互换享受 strided batch gemm 带来的加速，但是因为 oneflow 目前 view 机制的问题，享受不到这个加速，同时在 sbp 推导中会出现 [s, b, h, d] -> [s, b*h, d] 时，sbp 为 [s(1), s(2)] 无法继续推导

所以将 batch 和 seq 维度重新改变