### PR TITLE
add config system 

### DIFF
--- a/configs/bert_large_pretrain.py
+++ b/configs/bert_large_pretrain.py
@@ -1,4 +1,4 @@
-from libai.config import LazyCall as L
+from libai.config import LazyCall
 from .common.models.bert import pretrain_model as model
 from .common.train import train
 from .common.optim import optim, lr_scheduler
@@ -25,11 +25,11 @@ model.cfg.fp16 = train.amp.enabled
 graph = dict(
     # options for graph or eager mode
     enabled=True,
-    train=L(BertForPretrainingGraph)(
+    train=LazyCall(BertForPretrainingGraph)(
         fp16=train.amp.enabled,
         is_eval=False,
     ),
-    eval=L(BertForPretrainingGraph)(
+    eval=LazyCall(BertForPretrainingGraph)(
         fp16=train.amp.enabled, 
         is_eval=True,),
 )

--- a/configs/bert_large_pretrain.py
+++ b/configs/bert_large_pretrain.py
@@ -1,0 +1,36 @@
+from libai.config import LazyCall as L
+from .common.models.bert import pretrain_model as model
+from .common.train import train
+from .common.optim import optim, lr_scheduler
+from .common.data.nlp_data import data
+from libai.models import BertForPretrainingGraph
+
+# Bert-large model config
+model.cfg.num_attention_heads = 16
+model.cfg.hidden_size = 768
+model.cfg.hidden_layers = 8
+
+# Set pipeline layers for paralleleism
+train.dist.pipeline_num_layers = model.cfg.hidden_layers
+train.dist.tensor_parallel_size = 1
+train.dist.pipeline_parallel_size = 1
+
+train.micro_batch_size = 16
+
+train.amp.enabled = True
+
+model.cfg.fp16 = train.amp.enabled
+
+# fmt: off
+graph = dict(
+    # options for graph or eager mode
+    enabled=True,
+    train=L(BertForPretrainingGraph)(
+        fp16=train.amp.enabled,
+        is_eval=False,
+    ),
+    eval=L(BertForPretrainingGraph)(
+        fp16=train.amp.enabled, 
+        is_eval=True,),
+)
+# fmt: on

--- a/configs/bert_large_pretrain.py
+++ b/configs/bert_large_pretrain.py
@@ -12,14 +12,11 @@ model.cfg.hidden_layers = 8
 
 # Set pipeline layers for paralleleism
 train.dist.pipeline_num_layers = model.cfg.hidden_layers
-train.dist.tensor_parallel_size = 1
-train.dist.pipeline_parallel_size = 1
 
 train.micro_batch_size = 16
 
+# Set fp16 ON
 train.amp.enabled = True
-
-model.cfg.fp16 = train.amp.enabled
 
 # fmt: off
 graph = dict(

--- a/configs/bert_large_pretrain.py
+++ b/configs/bert_large_pretrain.py
@@ -1,8 +1,9 @@
 from libai.config import LazyCall
 from .common.models.bert import pretrain_model as model
 from .common.train import train
-from .common.optim import optim, lr_scheduler
+from .common.optim import optim, scheduler
 from .common.data.nlp_data import data
+
 from libai.models import BertForPretrainingGraph
 
 # Bert-large model config
@@ -21,7 +22,7 @@ train.amp.enabled = True
 # fmt: off
 graph = dict(
     # options for graph or eager mode
-    enabled=True,
+    enabled=False,
     train=LazyCall(BertForPretrainingGraph)(
         fp16=train.amp.enabled,
         is_eval=False,

--- a/configs/common/data/nlp_data.py
+++ b/configs/common/data/nlp_data.py
@@ -1,0 +1,37 @@
+data = dict(
+    # Pad the vocab size to be divisible by this value
+    # This is added for computational efficiency reasons.
+    make_vocab_size_divisible_by=128,
+    data_path=[
+        "/workspace/idea_model/idea_bert/output_data/loss_compara_content_sentence"
+    ],
+    split="949,50,1",
+    vocab_file="/workspace/idea_model/idea_bert/bert-base-chinese-vocab.txt",
+    merge_file=None,
+    vocab_extra_ids=0,
+    seq_length=512,
+    encoder_seq_length=None,
+    decoder_seq_length=None,
+    sample_rate=1.0,
+    mask_prob=0.15,
+    short_seq_prob=0.1,
+    mmap_warmup=True,
+    tokenizer_setup=True,
+    # What type of tokenizer to use
+    # "BertWordPieceLowerCase",
+    # "BertWordPieceCase",
+    # "GPT2BPETokenizer",
+    # "BertCNWWMTokenizer",
+    tokenizer_type="BertCNWWMTokenizer",
+    # What type of dataset to use
+    dataset_type="bert",
+    # Implementation of indexed datasets, choose from `lazy`, `cached`, `mmap`, `infer`.
+    data_impl="mmap",
+    reset_position_ids=False,
+    reset_attention_mask=False,
+    eod_mask_loss=False,
+    use_external_dataset=False,
+    # Dataloader type and number of workers
+    dataloader_type="single",
+    num_workers=4,
+)

--- a/configs/common/models/bert.py
+++ b/configs/common/models/bert.py
@@ -1,4 +1,4 @@
-from libai.config import LazyCall as L
+from libai.config import LazyCall
 
 from libai.models import BertModel, BertForPreTraining
 
@@ -21,6 +21,6 @@ cfg = dict(
     apply_query_key_layer_scaling=True,
 )
 
-bert_model = L(BertModel)(cfg=cfg)
+bert_model = LazyCall(BertModel)(cfg=cfg)
 
-pretrain_model = L(BertForPreTraining)(cfg=cfg)
+pretrain_model = LazyCall(BertForPreTraining)(cfg=cfg)

--- a/configs/common/models/bert.py
+++ b/configs/common/models/bert.py
@@ -1,0 +1,26 @@
+from libai.config import LazyCall as L
+
+from libai.models import BertModel, BertForPreTraining
+
+cfg = dict(
+    vocab_size=30522,
+    hidden_size=768,
+    hidden_layers=24,
+    num_attention_heads=12,
+    intermediate_size=4096,
+    hidden_dropout_prob=0.1,
+    attention_probs_dropout_prob=0.1,
+    max_position_embeddings=512,
+    num_tokentypes=2,
+    add_pooling_layer=True,
+    initializer_range=0.02,
+    layernorm_eps=1e-5,
+    bias_gelu_fusion=True,
+    bias_dropout_fusion=True,
+    scale_mask_softmax_fusion=False,
+    apply_query_key_layer_scaling=True,
+)
+
+bert_model = L(BertModel)(cfg=cfg)
+
+pretrain_model = L(BertForPreTraining)(cfg=cfg)

--- a/configs/common/optim.py
+++ b/configs/common/optim.py
@@ -1,5 +1,6 @@
 import oneflow as flow
 from libai.optim import get_default_optimizer_params
+from libai.scheduler import WarmupCosineAnnealingLR
 
 from libai.config import LazyCall
 
@@ -17,11 +18,6 @@ optim = LazyCall(flow.optim.AdamW)(
     do_bias_correction=True,
 )
 
-lr_scheduler = LazyCall(flow.optim.lr_scheduler.WarmUpLR)(
-    lrsch_or_optimizer=LazyCall(flow.optim.lr_scheduler.CosineDecayLR)(
-        decay_steps=1000, alpha=0.1,
-    ),
-    warmup_factor=0,
-    warmup_iters=100,
-    warmup_method="linear",
+scheduler = LazyCall(WarmupCosineAnnealingLR)(
+    t_max=1000, warmup_factor=0, warmup_iters=100, warmup_method="linear"
 )

--- a/configs/common/optim.py
+++ b/configs/common/optim.py
@@ -1,0 +1,25 @@
+import oneflow as flow
+from libai.optim import get_default_optimizer_params, PolynomialLR
+
+from libai.config import LazyCall as L
+
+optim = L(flow.optim.AdamW)(
+    parameters=L(get_default_optimizer_params)(
+        # parameters.model is meant to be set to the model object, before instantiating the optimizer.
+        clip_grad_max_norm=1.0,
+        clip_grad_norm_type=2.0,
+        weight_decay_norm=0.0,
+        weight_decay_bias=0.0,
+    ),
+    lr=1e-4,
+    weight_decay=0.01,
+    betas=(0.9, 0.999),
+    do_bias_correction=True,
+)
+
+lr_scheduler = L(flow.optim.lr_scheduler.WarmUpLR)(
+    lrsch_or_optimizer=L(PolynomialLR)(steps=1000, end_learning_rate=1.0e-5,),
+    warmup_factor=0,
+    warmup_iters=100,
+    warmup_method="linear",
+)

--- a/configs/common/optim.py
+++ b/configs/common/optim.py
@@ -1,10 +1,10 @@
 import oneflow as flow
-from libai.optim import get_default_optimizer_params, PolynomialLR
+from libai.optim import get_default_optimizer_params
 
-from libai.config import LazyCall as L
+from libai.config import LazyCall
 
-optim = L(flow.optim.AdamW)(
-    parameters=L(get_default_optimizer_params)(
+optim = LazyCall(flow.optim.AdamW)(
+    parameters=LazyCall(get_default_optimizer_params)(
         # parameters.model is meant to be set to the model object, before instantiating the optimizer.
         clip_grad_max_norm=1.0,
         clip_grad_norm_type=2.0,
@@ -17,8 +17,10 @@ optim = L(flow.optim.AdamW)(
     do_bias_correction=True,
 )
 
-lr_scheduler = L(flow.optim.lr_scheduler.WarmUpLR)(
-    lrsch_or_optimizer=L(PolynomialLR)(steps=1000, end_learning_rate=1.0e-5,),
+lr_scheduler = LazyCall(flow.optim.lr_scheduler.WarmUpLR)(
+    lrsch_or_optimizer=LazyCall(flow.optim.lr_scheduler.CosineDecayLR)(
+        decay_steps=1000, alpha=0.1,
+    ),
     warmup_factor=0,
     warmup_iters=100,
     warmup_method="linear",

--- a/configs/common/train.py
+++ b/configs/common/train.py
@@ -22,8 +22,6 @@ train = dict(
 
     # Distributed arguments
     dist=dict(
-        num_gpus_per_node=1,
-        num_nodes=1,
         data_parallel_size=1,
         tensor_parallel_size=1,
         pipeline_parallel_size=1,

--- a/configs/common/train.py
+++ b/configs/common/train.py
@@ -1,0 +1,38 @@
+# fmt: off
+train = dict(
+    output_dir="./demo_output/test_config",
+
+    micro_batch_size=32,
+    global_batch_size=None,
+    num_accumulation_steps=None,
+
+    start_iter=0,
+    train_iter=10000,
+    lr_decay_iter=None,
+    eval_iter=10000,
+    lr_warmup_fraction=0.01,
+    amp=dict(enabled=False),  # options for Automatic Mixed Precision
+    checkpointer=dict(period=5000, max_to_keep=100),  # options for PeriodicCheckpointer
+    load_weight="",
+    eval_period=5000,
+    log_period=20,
+    consumed_train_samples=0,
+    consumed_valid_samples=0,
+    train_samples=None,
+
+    # Distributed arguments
+    dist=dict(
+        num_gpus_per_node=1,
+        num_nodes=1,
+        data_parallel_size=1,
+        tensor_parallel_size=1,
+        pipeline_parallel_size=1,
+    ),
+    seed=1234,
+    # NCCL fusion threshold megabytes, set to 0 to compatible with previous version of OneFlow
+    nccl_fusion_threshold_mb=16,
+    # Maximum number of ops of NCCL fusion, set to 0 to compatible with previous version of OneFlow
+    nccl_fusion_max_ops=24,
+    enable_use_compute_stream=True,
+)
+# fmt: on

--- a/libai/config/__init__.py
+++ b/libai/config/__init__.py
@@ -1,0 +1,27 @@
+# coding=utf-8
+# Copyright 2021 The OneFlow Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .lazy import LazyCall, LazyConfig
+from .instantiate import instantiate
+from .arguments import default_argument_parser
+from .config import configurable
+
+__all__ = [
+    "LazyCall",
+    "LazyConfig",
+    "instantiate",
+    "default_argument_parser",
+    "configurable",
+]

--- a/libai/config/arguments.py
+++ b/libai/config/arguments.py
@@ -1,0 +1,98 @@
+# coding=utf-8
+# Copyright 2021 The OneFlow Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import os
+import sys
+import argparse
+
+
+def default_argument_parser(epilog=None):
+    """
+    Create a parser with some common arguments used by libai users.
+
+    Args:
+        epilog (str): epilog passed to ArgumentParser describing the usage.
+
+    Returns:
+        argparse.ArgumentParser:
+    """
+    parser = argparse.ArgumentParser(
+        epilog=epilog
+        or f"""
+Examples:
+
+Run on single machine:
+    $ {sys.argv[0]} --num-gpus 8 --config-file cfg.yaml
+
+Change some config options:
+    $ {sys.argv[0]} --config-file cfg.yaml MODEL.WEIGHTS /path/to/weight.pth SOLVER.BASE_LR 0.001
+
+Run on multiple machines:
+    (machine0)$ {sys.argv[0]} --machine-rank 0 --num-machines 2 --dist-url <URL> [--other-flags]
+    (machine1)$ {sys.argv[0]} --machine-rank 1 --num-machines 2 --dist-url <URL> [--other-flags]
+""",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--config-file", default="", metavar="FILE", help="path to config file"
+    )
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help="Whether to attempt to resume from the checkpoint directory. "
+        "See documentation of `DefaultTrainer.resume_or_load()` for what it means.",
+    )
+    parser.add_argument(
+        "--eval-only", action="store_true", help="perform evaluation only"
+    )
+    parser.add_argument(
+        "--num-gpus", type=int, default=1, help="number of gpus *per machine*"
+    )
+    parser.add_argument(
+        "--num-machines", type=int, default=1, help="total number of machines"
+    )
+    parser.add_argument(
+        "--machine-rank",
+        type=int,
+        default=0,
+        help="the rank of this machine (unique per machine)",
+    )
+
+    # OneFlow follows PyTorch's multi-process launch and it still may leave orphan processes in multi-gpu training.
+    # Therefore we use a deterministic way to obtain port,
+    # so that users are aware of orphan processes by seeing the port occupied.
+    port = (
+        2 ** 15
+        + 2 ** 14
+        + hash(os.getuid() if sys.platform != "win32" else 1) % 2 ** 14
+    )
+    parser.add_argument(
+        "--dist-url",
+        default="tcp://127.0.0.1:{}".format(port),
+        help="initialization URL for pytorch distributed backend. See "
+        "https://pytorch.org/docs/stable/distributed.html for details.",
+    )
+    parser.add_argument(
+        "opts",
+        help="""
+Modify config options at the end of the command. For Yacs configs, use
+space-separated "path.key value" pairs.
+For python-based LazyConfig, use "path.key=value".
+        """.strip(),
+        default=None,
+        nargs=argparse.REMAINDER,
+    )
+    return parser

--- a/libai/config/config.py
+++ b/libai/config/config.py
@@ -29,20 +29,25 @@ def configurable(init_func=None, *, from_config=None):
             @configurable
             def __init__(self, a, b=2, c=3):
                 pass
+
             @classmethod
             def from_config(cls, cfg):   # 'cfg' must be the first argument
                 # Returns kwargs to be passed to __init__
                 return {"a": cfg.A, "b": cfg.B}
+
         a1 = A(a=1, b=2)  # regular construction
         a2 = A(cfg)       # construct with a cfg
         a3 = A(cfg, b=3, c=4)  # construct with extra overwrite
+
         # Usage 2: Decorator on any function. Needs an extra from_config argument:
         @configurable(from_config=lambda cfg: {"a: cfg.A, "b": cfg.B})
         def a_func(a, b=2, c=3):
             pass
+
         a1 = a_func(a=1, b=2)  # regular call
         a2 = a_func(cfg)       # call with a cfg
         a3 = a_func(cfg, b=3, c=4)  # call with extra overwrite
+
     Args:
         init_func (callable): a class's ``__init__`` method in usage 1. The
             class must have a ``from_config`` classmethod which takes `cfg` as

--- a/libai/config/config.py
+++ b/libai/config/config.py
@@ -1,0 +1,152 @@
+# coding=utf-8
+# Copyright 2021 The OneFlow Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import functools
+import inspect
+
+
+def configurable(init_func=None, *, from_config=None):
+    """
+    Decorate a function or a class's __init__ method so that it can be called
+    with a :class:`CfgNode` object using a :func:`from_config` function that translates
+    :class:`CfgNode` to arguments.
+    Examples:
+    ::
+        # Usage 1: Decorator on __init__:
+        class A:
+            @configurable
+            def __init__(self, a, b=2, c=3):
+                pass
+            @classmethod
+            def from_config(cls, cfg):   # 'cfg' must be the first argument
+                # Returns kwargs to be passed to __init__
+                return {"a": cfg.A, "b": cfg.B}
+        a1 = A(a=1, b=2)  # regular construction
+        a2 = A(cfg)       # construct with a cfg
+        a3 = A(cfg, b=3, c=4)  # construct with extra overwrite
+        # Usage 2: Decorator on any function. Needs an extra from_config argument:
+        @configurable(from_config=lambda cfg: {"a: cfg.A, "b": cfg.B})
+        def a_func(a, b=2, c=3):
+            pass
+        a1 = a_func(a=1, b=2)  # regular call
+        a2 = a_func(cfg)       # call with a cfg
+        a3 = a_func(cfg, b=3, c=4)  # call with extra overwrite
+    Args:
+        init_func (callable): a class's ``__init__`` method in usage 1. The
+            class must have a ``from_config`` classmethod which takes `cfg` as
+            the first argument.
+        from_config (callable): the from_config function in usage 2. It must take `cfg`
+            as its first argument.
+    """
+
+    if init_func is not None:
+        assert (
+            inspect.isfunction(init_func)
+            and from_config is None
+            and init_func.__name__ == "__init__"
+        ), "Incorrect use of @configurable. Check API documentation for examples."
+
+        @functools.wraps(init_func)
+        def wrapped(self, *args, **kwargs):
+            try:
+                from_config_func = type(self).from_config
+            except AttributeError as e:
+                raise AttributeError(
+                    "Class with @configurable must have a 'from_config' classmethod."
+                ) from e
+            if not inspect.ismethod(from_config_func):
+                raise TypeError(
+                    "Class with @configurable must have a 'from_config' classmethod."
+                )
+
+            if _called_with_cfg(*args, **kwargs):
+                explicit_args = _get_args_from_config(from_config_func, *args, **kwargs)
+                init_func(self, **explicit_args)
+            else:
+                init_func(self, *args, **kwargs)
+
+        return wrapped
+
+    else:
+        if from_config is None:
+            return configurable  # @configurable() is made equivalent to @configurable
+        assert inspect.isfunction(
+            from_config
+        ), "from_config argument of configurable must be a function!"
+
+        def wrapper(orig_func):
+            @functools.wraps(orig_func)
+            def wrapped(*args, **kwargs):
+                if _called_with_cfg(*args, **kwargs):
+                    explicit_args = _get_args_from_config(from_config, *args, **kwargs)
+                    return orig_func(**explicit_args)
+                else:
+                    return orig_func(*args, **kwargs)
+
+            wrapped.from_config = from_config
+            return wrapped
+
+        return wrapper
+
+
+def _get_args_from_config(from_config_func, *args, **kwargs):
+    """
+    Use `from_config` to obtain explicit arguments.
+    Returns:
+        dict: arguments to be used for cls.__init__
+    """
+    signature = inspect.signature(from_config_func)
+    if list(signature.parameters.keys())[0] != "cfg":
+        if inspect.isfunction(from_config_func):
+            name = from_config_func.__name__
+        else:
+            name = f"{from_config_func.__self__}.from_config"
+        raise TypeError(f"{name} must take 'cfg' as the first argument!")
+    support_var_arg = any(
+        param.kind in [param.VAR_POSITIONAL, param.VAR_KEYWORD]
+        for param in signature.parameters.values()
+    )
+    if (
+        support_var_arg
+    ):  # forward all arguments to from_config, if from_config accepts them
+        ret = from_config_func(*args, **kwargs)
+    else:
+        # forward supported arguments to from_config
+        supported_arg_names = set(signature.parameters.keys())
+        extra_kwargs = {}
+        for name in list(kwargs.keys()):
+            if name not in supported_arg_names:
+                extra_kwargs[name] = kwargs.pop(name)
+        ret = from_config_func(*args, **kwargs)
+        # forward the other arguments to __init__
+        ret.update(extra_kwargs)
+    return ret
+
+
+def _called_with_cfg(*args, **kwargs):
+    """
+    Returns:
+        bool: whether the arguments contain CfgNode and should be considered
+            forwarded to from_config.
+    """
+    from omegaconf import DictConfig
+
+    if len(args) and isinstance(args[0], DictConfig):
+        return True
+    if isinstance(kwargs.pop("cfg", None), DictConfig):
+        return True
+    # `from_config`'s first argument is forced to be "cfg".
+    # So the above check covers all cases.
+    return False

--- a/libai/config/instantiate.py
+++ b/libai/config/instantiate.py
@@ -1,0 +1,96 @@
+# coding=utf-8
+# Copyright 2021 The OneFlow Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import dataclasses
+import logging
+from collections import abc
+from typing import Any
+
+from libai.config.lazy import _convert_target_to_string, locate
+
+__all__ = ["dump_dataclass", "instantiate"]
+
+
+def dump_dataclass(obj: Any):
+    """
+    Dump a dataclass recursively into a dict that can be later instantiated.
+
+    Args:
+        obj: a dataclass object
+
+    Returns:
+        dict
+    """
+    assert dataclasses.is_dataclass(obj) and not isinstance(
+        obj, type
+    ), "dump_dataclass() requires an instance of a dataclass."
+    ret = {"_target_": _convert_target_to_string(type(obj))}
+    for f in dataclasses.fields(obj):
+        v = getattr(obj, f.name)
+        if dataclasses.is_dataclass(v):
+            v = dump_dataclass(v)
+        if isinstance(v, (list, tuple)):
+            v = [dump_dataclass(x) if dataclasses.is_dataclass(x) else x for x in v]
+        ret[f.name] = v
+    return ret
+
+
+def instantiate(cfg):
+    """
+    Recursively instantiate objects defined in dictionaries by
+    "_target_" and arguments.
+
+    Args:
+        cfg: a dict-like object with "_target_" that defines the caller, and
+            other keys that define the arguments
+
+    Returns:
+        object instantiated by cfg
+    """
+    from omegaconf import ListConfig
+
+    if isinstance(cfg, ListConfig):
+        lst = [instantiate(x) for x in cfg]
+        return ListConfig(lst, flags={"allow_objects": True})
+    if isinstance(cfg, list):
+        # Specialize for list, because many classes take
+        # list[objects] as arguments, such as ResNet, DatasetMapper
+        return [instantiate(x) for x in cfg]
+
+    if isinstance(cfg, abc.Mapping) and "_target_" in cfg:
+        # conceptually equivalent to hydra.utils.instantiate(cfg) with _convert_=all,
+        # but faster: https://github.com/facebookresearch/hydra/issues/1200
+        cfg = {k: instantiate(v) for k, v in cfg.items()}
+        cls = cfg.pop("_target_")
+        cls = instantiate(cls)
+
+        if isinstance(cls, str):
+            cls_name = cls
+            cls = locate(cls_name)
+            assert cls is not None, cls_name
+        else:
+            try:
+                cls_name = cls.__module__ + "." + cls.__qualname__
+            except Exception:
+                # target could be anything, so the above could fail
+                cls_name = str(cls)
+        assert callable(cls), f"_target_ {cls} does not define a callable object"
+        try:
+            return cls(**cfg)
+        except TypeError:
+            logger = logging.getLogger(__name__)
+            logger.error(f"Error when instantiating {cls_name}!")
+            raise
+    return cfg  # return as-is if don't know what to do

--- a/libai/config/lazy.py
+++ b/libai/config/lazy.py
@@ -1,0 +1,452 @@
+# coding=utf-8
+# Copyright 2021 The OneFlow Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pydoc
+import ast
+import builtins
+import importlib
+import inspect
+import logging
+import os
+import uuid
+from collections import abc
+from contextlib import contextmanager
+from copy import deepcopy
+from dataclasses import is_dataclass
+from typing import List, Tuple, Union, Any
+import cloudpickle
+import yaml
+from omegaconf import DictConfig, ListConfig, OmegaConf
+
+__all__ = ["LazyCall", "LazyConfig"]
+
+
+def locate(name: str) -> Any:
+    """
+    Locate and return an object ``x`` using an input string ``{x.__module__}.{x.__qualname__}``,
+    such as "module.submodule.class_name".
+    Raise Exception if it cannot be found.
+    """
+    obj = pydoc.locate(name)
+
+    # Some cases (e.g. torch.optim.sgd.SGD) not handled correctly
+    # by pydoc.locate. Try a private function from hydra.
+    if obj is None:
+        try:
+            # from hydra.utils import get_method - will print many errors
+            from hydra.utils import _locate
+        except ImportError as e:
+            raise ImportError(f"Cannot dynamically locate object {name}!") from e
+        else:
+            obj = _locate(name)  # it raises if fails
+
+    return obj
+
+
+def _convert_target_to_string(t: Any) -> str:
+    """
+    Inverse of ``locate()``.
+    Args:
+        t: any object with ``__module__`` and ``__qualname__``
+    """
+    module, qualname = t.__module__, t.__qualname__
+
+    # Compress the path to this object, e.g. ``module.submodule._impl.class``
+    # may become ``module.submodule.class``, if the later also resolves to the same
+    # object. This simplifies the string, and also is less affected by moving the
+    # class implementation.
+    module_parts = module.split(".")
+    for k in range(1, len(module_parts)):
+        prefix = ".".join(module_parts[:k])
+        candidate = f"{prefix}.{qualname}"
+        try:
+            if locate(candidate) is t:
+                return candidate
+        except ImportError:
+            pass
+    return f"{module}.{qualname}"
+
+
+class LazyCall:
+    """
+    Wrap a callable so that when it's called, the call will not be executed,
+    but returns a dict that describes the call.
+    LazyCall object has to be called with only keyword arguments. Positional
+    arguments are not yet supported.
+    Examples:
+    ::
+        from libai.config import instantiate, LazyCall
+        layer_cfg = LazyCall(nn.Conv2d)(in_channels=32, out_channels=32)
+        layer_cfg.out_channels = 64   # can edit it afterwards
+        layer = instantiate(layer_cfg)
+    """
+
+    def __init__(self, target):
+        if not (callable(target) or isinstance(target, (str, abc.Mapping))):
+            raise TypeError(
+                f"target of LazyCall must be a callable or defines a callable! Got {target}"
+            )
+        self._target = target
+
+    def __call__(self, **kwargs):
+        if is_dataclass(self._target):
+            # omegaconf object cannot hold dataclass type
+            # https://github.com/omry/omegaconf/issues/784
+            target = _convert_target_to_string(self._target)
+        else:
+            target = self._target
+        kwargs["_target_"] = target
+
+        return DictConfig(content=kwargs, flags={"allow_objects": True})
+
+
+def _visit_dict_config(cfg, func):
+    """
+    Apply func recursively to all DictConfig in cfg.
+    """
+    if isinstance(cfg, DictConfig):
+        func(cfg)
+        for v in cfg.values():
+            _visit_dict_config(v, func)
+    elif isinstance(cfg, ListConfig):
+        for v in cfg:
+            _visit_dict_config(v, func)
+
+
+def _validate_py_syntax(filename):
+    # see also https://github.com/open-mmlab/mmcv/blob/master/mmcv/utils/config.py
+    with open(filename, "r", encoding="utf-8") as f:
+        # Setting encoding explicitly to resolve coding issue on windows
+        content = f.read()
+    try:
+        ast.parse(content)
+    except SyntaxError as e:
+        raise SyntaxError(f"Config file {filename} has syntax error!") from e
+
+
+def _cast_to_config(obj):
+    # if given a dict, return DictConfig instead
+    if isinstance(obj, dict):
+        return DictConfig(obj, flags={"allow_objects": True})
+    return obj
+
+
+_CFG_PACKAGE_NAME = "libai._cfg_loader"
+"""
+A namespace to put all imported config into.
+"""
+
+
+def _random_package_name(filename):
+    # generate a random package name when loading config files
+    return _CFG_PACKAGE_NAME + str(uuid.uuid4())[:4] + "." + os.path.basename(filename)
+
+
+@contextmanager
+def _patch_import():
+    """
+    Enhance relative import statements in config files, so that they:
+    1. locate files purely based on relative location, regardless of packages.
+       e.g. you can import file without having __init__
+    2. do not cache modules globally; modifications of module states has no side effect
+    3. support other storage system through PathManager
+    4. imported dict are turned into omegaconf.DictConfig automatically
+    """
+    old_import = builtins.__import__
+
+    def find_relative_file(original_file, relative_import_path, level):
+        cur_file = os.path.dirname(original_file)
+        for _ in range(level - 1):
+            cur_file = os.path.dirname(cur_file)
+        cur_name = relative_import_path.lstrip(".")
+        for part in cur_name.split("."):
+            cur_file = os.path.join(cur_file, part)
+        # NOTE: directory import is not handled. Because then it's unclear
+        # if such import should produce python module or DictConfig. This can
+        # be discussed further if needed.
+        if not cur_file.endswith(".py"):
+            cur_file += ".py"
+        if not os.path.isfile(cur_file):
+            raise ImportError(
+                f"Cannot import name {relative_import_path} from "
+                f"{original_file}: {cur_file} has to exist."
+            )
+        return cur_file
+
+    def new_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if (
+            # Only deal with relative imports inside config files
+            level != 0
+            and globals is not None
+            and (globals.get("__package__", "") or "").startswith(_CFG_PACKAGE_NAME)
+        ):
+            cur_file = find_relative_file(globals["__file__"], name, level)
+            _validate_py_syntax(cur_file)
+            spec = importlib.machinery.ModuleSpec(
+                _random_package_name(cur_file), None, origin=cur_file
+            )
+            module = importlib.util.module_from_spec(spec)
+            module.__file__ = cur_file
+            with open(cur_file, "r", encoding="utf-8") as f:
+                content = f.read()
+            exec(compile(content, cur_file, "exec"), module.__dict__)
+            for name in fromlist:  # turn imported dict into DictConfig automatically
+                val = _cast_to_config(module.__dict__[name])
+                module.__dict__[name] = val
+            return module
+        return old_import(name, globals, locals, fromlist=fromlist, level=level)
+
+    builtins.__import__ = new_import
+    yield new_import
+    builtins.__import__ = old_import
+
+
+class LazyConfig:
+    """
+    Provide methods to save, load, and overrides an omegaconf config object
+    which may contain definition of lazily-constructed objects.
+    """
+
+    @staticmethod
+    def load_rel(filename: str, keys: Union[None, str, Tuple[str, ...]] = None):
+        """
+        Similar to :meth:`load()`, but load path relative to the caller's
+        source file.
+        This has the same functionality as a relative import, except that this method
+        accepts filename as a string, so more characters are allowed in the filename.
+        """
+        caller_frame = inspect.stack()[1]
+        caller_fname = caller_frame[0].f_code.co_filename
+        assert caller_fname != "<string>", "load_rel Unable to find caller"
+        caller_dir = os.path.dirname(caller_fname)
+        filename = os.path.join(caller_dir, filename)
+        return LazyConfig.load(filename, keys)
+
+    @staticmethod
+    def load(filename: str, keys: Union[None, str, Tuple[str, ...]] = None):
+        """
+        Load a config file.
+        Args:
+            filename: absolute path or relative path w.r.t. the current working directory
+            keys: keys to load and return. If not given, return all keys
+                (whose values are config objects) in a dict.
+        """
+        has_keys = keys is not None
+        filename = filename.replace("/./", "/")  # redundant
+        if os.path.splitext(filename)[1] not in [".py", ".yaml", ".yml"]:
+            raise ValueError(f"Config file {filename} has to be a python or yaml file.")
+        if filename.endswith(".py"):
+            _validate_py_syntax(filename)
+
+            with _patch_import():
+                # Record the filename
+                module_namespace = {
+                    "__file__": filename,
+                    "__package__": _random_package_name(filename),
+                }
+                with open(filename, "r", encoding="utf-8") as f:
+                    content = f.read()
+                # Compile first with filename to:
+                # 1. make filename appears in stacktrace
+                # 2. make load_rel able to find its parent's (possibly remote) location
+                exec(compile(content, filename, "exec"), module_namespace)
+
+            ret = module_namespace
+        else:
+            with open(filename, "r", encoding="utf-8") as f:
+                obj = yaml.unsafe_load(f)
+            ret = OmegaConf.create(obj, flags={"allow_objects": True})
+
+        if has_keys:
+            if isinstance(keys, str):
+                return _cast_to_config(ret[keys])
+            else:
+                return tuple(_cast_to_config(ret[a]) for a in keys)
+        else:
+            if filename.endswith(".py"):
+                # when not specified, only load those that are config objects
+                ret = DictConfig(
+                    {
+                        name: _cast_to_config(value)
+                        for name, value in ret.items()
+                        if isinstance(value, (DictConfig, ListConfig, dict))
+                        and not name.startswith("_")
+                    },
+                    flags={"allow_objects": True},
+                )
+            return ret
+
+    @staticmethod
+    def save(cfg, filename: str):
+        """
+        Save a config object to a yaml file.
+        Note that when the config dictionary contains complex objects (e.g. lambda),
+        it can't be saved to yaml. In that case we will print an error and
+        attempt to save to a pkl file instead.
+        Args:
+            cfg: an omegaconf config object
+            filename: yaml file name to save the config file
+        """
+        logger = logging.getLogger(__name__)
+        try:
+            cfg = deepcopy(cfg)
+        except Exception:
+            pass
+        else:
+            # if it's deep-copyable, then...
+            def _replace_type_by_name(x):
+                if "_target_" in x and callable(x._target_):
+                    try:
+                        x._target_ = _convert_target_to_string(x._target_)
+                    except AttributeError:
+                        pass
+
+            # not necessary, but makes yaml looks nicer
+            _visit_dict_config(cfg, _replace_type_by_name)
+
+        save_pkl = False
+        try:
+            dict = OmegaConf.to_container(cfg, resolve=False)
+            dumped = yaml.dump(
+                dict, default_flow_style=None, allow_unicode=True, width=9999
+            )
+            with open(filename, "w") as f:
+                f.write(dumped)
+
+            try:
+                _ = yaml.unsafe_load(dumped)  # test that it is loadable
+            except Exception:
+                logger.warning(
+                    "The config contains objects that cannot serialize to a valid yaml. "
+                    f"{filename} is human-readable but cannot be loaded."
+                )
+                save_pkl = True
+        except Exception:
+            logger.exception("Unable to serialize the config to yaml. Error:")
+            save_pkl = True
+
+        if save_pkl:
+            new_filename = filename + ".pkl"
+            try:
+                # retry by pickle
+                with open(new_filename, "wb") as f:
+                    cloudpickle.dump(cfg, f)
+                logger.warning(f"Config is saved using cloudpickle at {new_filename}.")
+            except Exception:
+                pass
+
+    @staticmethod
+    def apply_overrides(cfg, overrides: List[str]):
+        """
+        In-place override contents of cfg.
+        Args:
+            cfg: an omegaconf config object
+            overrides: list of strings in the format of "a=b" to override configs.
+                See https://hydra.cc/docs/next/advanced/override_grammar/basic/
+                for syntax.
+        Returns:
+            the cfg object
+        """
+
+        def safe_update(cfg, key, value):
+            parts = key.split(".")
+            for idx in range(1, len(parts)):
+                prefix = ".".join(parts[:idx])
+                v = OmegaConf.select(cfg, prefix, default=None)
+                if v is None:
+                    break
+                if not OmegaConf.is_config(v):
+                    raise KeyError(
+                        f"Trying to update key {key}, but {prefix} "
+                        f"is not a config, but has type {type(v)}."
+                    )
+            OmegaConf.update(cfg, key, value, merge=True)
+
+        from hydra.core.override_parser.overrides_parser import OverridesParser
+
+        parser = OverridesParser.create()
+        overrides = parser.parse_overrides(overrides)
+        for o in overrides:
+            key = o.key_or_group
+            value = o.value()
+            if o.is_delete():
+                # TODO support this
+                raise NotImplementedError("deletion is not yet a supported override")
+            safe_update(cfg, key, value)
+        return cfg
+
+    @staticmethod
+    def to_py(cfg, prefix: str = "cfg."):
+        """
+        Try to convert a config object into Python-like pseudo code.
+        Note that perfect conversion is not always possible. So the returned
+        results are mainly meant to be human-readable, and not meant to be executed.
+        Args:
+            cfg: an omegaconf config object
+            prefix: root name for the resulting code (default: "cfg.")
+        Returns:
+            str of formatted Python code
+        """
+        import black
+
+        cfg = OmegaConf.to_container(cfg, resolve=True)
+
+        def _to_str(obj, prefix=None, inside_call=False):
+            if prefix is None:
+                prefix = []
+            if isinstance(obj, abc.Mapping) and "_target_" in obj:
+                # Dict representing a function call
+                target = _convert_target_to_string(obj.pop("_target_"))
+                args = []
+                for k, v in sorted(obj.items()):
+                    args.append(f"{k}={_to_str(v, inside_call=True)}")
+                args = ", ".join(args)
+                call = f"{target}({args})"
+                return "".join(prefix) + call
+            elif isinstance(obj, abc.Mapping) and not inside_call:
+                # Dict that is not inside a call is a list of top-level config objects that we
+                # render as one object per line with dot separated prefixes
+                key_list = []
+                for k, v in sorted(obj.items()):
+                    if isinstance(v, abc.Mapping) and "_target_" not in v:
+                        key_list.append(_to_str(v, prefix=prefix + [k + "."]))
+                    else:
+                        key = "".join(prefix) + k
+                        key_list.append(f"{key}={_to_str(v)}")
+                return "\n".join(key_list)
+            elif isinstance(obj, abc.Mapping):
+                # Dict that is inside a call is rendered as a regular dict
+                return (
+                    "{"
+                    + ",".join(
+                        f"{repr(k)}: {_to_str(v, inside_call=inside_call)}"
+                        for k, v in sorted(obj.items())
+                    )
+                    + "}"
+                )
+            elif isinstance(obj, list):
+                return (
+                    "["
+                    + ",".join(_to_str(x, inside_call=inside_call) for x in obj)
+                    + "]"
+                )
+            else:
+                return repr(obj)
+
+        py_str = _to_str(cfg, prefix=[prefix])
+        try:
+            return black.format_str(py_str, mode=black.Mode())
+        except black.InvalidInput:
+            return py_str

--- a/libai/models/__init__.py
+++ b/libai/models/__init__.py
@@ -14,8 +14,10 @@
 # limitations under the License.
 
 from .bert_model import BertModel, BertForPreTraining
+from .build import build_model
 
 __all__ = [
+    "build_model",
     "BertModel",
     "BertForPreTraining",
 ]

--- a/libai/models/bert_model.py
+++ b/libai/models/bert_model.py
@@ -31,6 +31,8 @@ from libai.config import configurable
 
 from .utils import init_method_normal, scaled_init_method_normal
 
+from .build import MODEL_ARCH_REGISTRY
+
 
 class BertExtendedAttnMask(nn.Module):
     def forward(self, attention_mask):
@@ -311,6 +313,7 @@ class BertEncoder(nn.Module):
         return output
 
 
+@MODEL_ARCH_REGISTRY.register()
 class BertModel(nn.Module):
     """Bert language model"""
 
@@ -405,6 +408,7 @@ class BertModel(nn.Module):
         return self.embeddings.word_embeddings()
 
 
+@MODEL_ARCH_REGISTRY.register()
 class BertForPreTraining(nn.Module):
     def __init__(self, cfg):
         super().__init__()

--- a/libai/models/build.py
+++ b/libai/models/build.py
@@ -1,0 +1,37 @@
+# coding=utf-8
+# Copyright 2021 The OneFlow Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from libai.config import instantiate
+from libai.utils.registry import Registry
+
+MODEL_ARCH_REGISTRY = Registry("model_arch")
+MODEL_ARCH_REGISTRY.__doc__ = """
+Registry for modeling, i.e. Bert or GPT model.
+
+The registered object will be called with `obj(cfg)` 
+and expected to return a `nn.Module` object.
+"""
+
+
+def build_model(cfg):
+    """ Build the whole model architecture, defined by ``cfg.model.model_arch``.
+    Note that is does not load any weights from ``cfg``.
+    """
+    if "_target_" in cfg.model:  # LazyCall
+        model = instantiate(cfg.model)
+    else:
+        model_arch = cfg.model.model_arch
+        model = MODEL_ARCH_REGISTRY.get(model_arch)(cfg.model.model_cfg)
+    return model

--- a/libai/models/build.py
+++ b/libai/models/build.py
@@ -29,9 +29,9 @@ def build_model(cfg):
     """ Build the whole model architecture, defined by ``cfg.model.model_arch``.
     Note that is does not load any weights from ``cfg``.
     """
-    if "_target_" in cfg.model:  # LazyCall
-        model = instantiate(cfg.model)
+    if "_target_" in cfg:  # LazyCall
+        model = instantiate(cfg)
     else:
-        model_arch = cfg.model.model_arch
-        model = MODEL_ARCH_REGISTRY.get(model_arch)(cfg.model.model_cfg)
+        model_name = cfg.model_name
+        model = MODEL_ARCH_REGISTRY.get(model_name)(cfg.model_cfg)
     return model

--- a/libai/optim/__init__.py
+++ b/libai/optim/__init__.py
@@ -1,0 +1,16 @@
+# coding=utf-8
+# Copyright 2021 The OneFlow Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .build import get_default_optimizer_params

--- a/libai/optim/build.py
+++ b/libai/optim/build.py
@@ -1,0 +1,137 @@
+# coding=utf-8
+# Copyright 2021 The OneFlow Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections import defaultdict
+import copy
+import oneflow as flow
+from typing import List, Dict, Any
+from libai.layers import LayerNorm
+
+
+def get_default_optimizer_params(
+    model,
+    base_lr=None,
+    weight_decay=None,
+    weight_decay_norm=None,
+    weight_decay_bias=None,
+    clip_grad_max_norm=None,
+    clip_grad_norm_type=None,
+    overrides=None,
+):
+    """
+    Get default param list for optimizer, with suport for a few types of overrides. If no overrides needed, this is equivalent to `model.parameters()`.
+    
+    Arguments:
+        base_lr: lr for every group by default. Can be omitted to use the one in optimizer.
+        weight_decay: weight decay for every group by default. Can be omitted to use the one
+            in optimizer.
+        weight_decay_norm: override weight decay for params in normalization layers
+        weight_decay_bias: override weight decay for bias parameters
+        overrides: if not `None`, provides values for optimizer hyperparameters
+            (LR, weight decay) for module parameters with a given name; e.g.
+            ``{"embedding": {"lr": 0.01, "weight_decay": 0.1}}`` will set the LR and
+            weight decay values for all module parameters named `embedding`.
+
+    For common transformer models, ``weight_decay_norm,weight_decay_bias`` is usually set to 0. 
+
+    Example:
+    ::
+        flow.optim.AdamW(get_default_optimizer_params(model, weight_decay_norm=0, weight_decay_bias=0),
+                       lr=0.01, weight_decay=1e-4)
+    """
+    if overrides is None:
+        overrides = {}
+    defaults = {}
+    if base_lr is not None:
+        defaults["lr"] = base_lr
+    if weight_decay is not None:
+        defaults["weight_decay"] = weight_decay
+    if clip_grad_max_norm is not None and clip_grad_norm_type is not None:
+        defaults["clip_grad_max_norm"] = clip_grad_max_norm
+        defaults["clip_grad_norm_type"] = clip_grad_norm_type
+    bias_overrides = {}
+    if weight_decay_bias is not None:
+        bias_overrides["weight_decay"] = weight_decay_bias
+    if len(bias_overrides):
+        if "bias" in overrides:
+            raise ValueError("Conflicting overrides for 'bias'")
+        overrides["bias"] = bias_overrides
+
+    norm_module_types = (
+        LayerNorm,
+        flow.nn.BatchNorm1d,
+        flow.nn.BatchNorm2d,
+        flow.nn.BatchNorm3d,
+        flow.nn.GroupNorm,
+        flow.nn.InstanceNorm1d,
+        flow.nn.InstanceNorm2d,
+        flow.nn.InstanceNorm3d,
+        flow.nn.FusedBatchNorm1d,
+        flow.nn.FusedBatchNorm2d,
+        flow.nn.FusedBatchNorm3d,
+    )
+    params = []
+    memo = set()
+    for module in model.modules():
+        for model_param_name, value in module.named_parameters(recurse=False):
+            if not value.requires_grad:
+                continue
+            # Avoid duplicating parameters
+            if value in memo:
+                continue
+            memo.add(value)
+
+            hyperparams = copy.copy(defaults)
+            if isinstance(module, norm_module_types) and weight_decay_norm is not None:
+                hyperparams["weight_decay"] = weight_decay_norm
+            hyperparams.update(overrides.get(model_param_name, {}))
+            params.append({"params": [value], **hyperparams})
+    return reduce_param_groups(params)
+
+
+def _expand_param_groups(params: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """ 
+    Transform parameter groups into per-parameter structure.
+    Later items in `params` can overwrite parameters set in previous items.
+    """
+    ret = defaultdict(dict)
+    for item in params:
+        assert "params" in item
+        cur_params = {x: y for x, y in item.items() if x != "params"}
+        for param in item["params"]:
+            ret[param].update({"params": [param], **cur_params})
+    return list(ret.values())
+
+
+def reduce_param_groups(params: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """
+    Reorganize the parameter groups and merge duplicated groups.
+    The number of parameter groups needs to be as small as possible in order
+    to efficiently use the PyTorch multi-tensor optimizer. Therefore instead
+    of using a parameter_group per single parameter, we reorganize the
+    parameter groups and merge duplicated groups. This approach speeds
+    up multi-tensor optimizer significantly.
+    """
+    params = _expand_param_groups(params)
+    groups = defaultdict(list)  # re-group all parameter groups by their hyperparams
+    for item in params:
+        cur_params = tuple((x, y) for x, y in item.items() if x != "params")
+        groups[cur_params].extend(item["params"])
+    ret = []
+    for param_keys, param_values in groups.items():
+        cur = {kv[0]: kv[1] for kv in param_keys}
+        cur["params"] = param_values
+        ret.append(cur)
+    return ret

--- a/libai/trainer/default.py
+++ b/libai/trainer/default.py
@@ -165,7 +165,7 @@ def default_setup(cfg, args):
     num_gpus_per_node = flow.env.get_world_size() // num_nodes
 
     if (
-        _try_get_key(cfg, "train.dist.num_gpus_per_node", num_gpus_per_node)
+        _try_get_key(cfg, "train.dist.num_gpus_per_node", default=num_gpus_per_node)
         != num_gpus_per_node
     ):
         # This means key(num_gpus_per_node) saved in config is not equal to environment variable.
@@ -174,13 +174,13 @@ def default_setup(cfg, args):
             f"Warning! num_gpus_per_node are not equal in cfg and environment variable. {cfg.train.dist.num_gpus_per_node} != {num_gpus_per_node}"
         )
 
-    if _try_get_key(cfg, "train.dist.num_nodes", num_nodes) != num_nodes:
+    if _try_get_key(cfg, "train.dist.num_nodes", default=num_nodes) != num_nodes:
         logger.info(
             f"Warning! num_nodes are not equal in cfg and environment variable. {cfg.train.dist.num_nodes} != {num_nodes}"
         )
 
-    cfg.train.dist_num_gpus_per_node = num_gpus_per_node
-    cfg.train.dist.num_nodes = args.num_machines
+    cfg.train.dist.num_nodes = num_nodes
+    cfg.train.dist.num_gpus_per_node = num_gpus_per_node
 
     dist.setup_dist_util(cfg.train.dist)
 

--- a/libai/trainer/default.py
+++ b/libai/trainer/default.py
@@ -21,7 +21,8 @@ import oneflow as flow
 from libai.config import LazyConfig, instantiate
 from libai.trainer import hooks
 from libai.trainer.trainer import EagerTrainer, GraphTrainer, TrainerBase
-from libai.models.build import build_model
+from libai.models import build_model
+from libai.scheduler import build_lr_scheduler
 from libai.optim import build_optimizer
 from libai.utils import distributed as dist
 from libai.utils.checkpoint import Checkpointer
@@ -119,8 +120,6 @@ def _check_batch_size(cfg):
         )
     else:
         raise ValueError("micro_batch_size and global_batch_size must be set either")
-
-from libai.scheduler import build_lr_scheduler
 
 
 def default_setup(cfg, args):
@@ -389,13 +388,13 @@ class DefaultTrainer(TrainerBase):
         """
         Returns:
             flow.nn.Module:
-        It now calls :func:`libai.layers.build_model`.
+        It now calls :func:`libai.models.build_model`.
         Overwrite it if you'd like a different model.
         """
         assert (
             _try_get_key(cfg, "model") is not None
         ), "cfg must contain `model` namespace"
-        model = build_model(cfg)
+        model = build_model(cfg.model)
         logger = logging.getLogger(__name__)
         logger.info("Model:\n{}".format(model))
         return model
@@ -424,6 +423,9 @@ class DefaultTrainer(TrainerBase):
         It now calls :func:`libai.optim.build_optimizer`.
         Overwrite it if you'd like a different optimizer.
         """
+        assert (
+            _try_get_key(cfg, "optim") is not None
+        ), "cfg must contain `optim` namespace"
         return build_optimizer(cfg.optim, model)
 
     @classmethod
@@ -432,6 +434,9 @@ class DefaultTrainer(TrainerBase):
         It now calls :func:`libai.scheduler.build_lr_scheduler`.
         Overwrite it if you'd like a different scheduler.
         """
+        assert (
+            _try_get_key(cfg, "scheduler") is not None
+        ), "cfg must contain `scheduler` namespace"
         return build_lr_scheduler(cfg.scheduler, optimizer)
 
     @classmethod

--- a/libai/trainer/default.py
+++ b/libai/trainer/default.py
@@ -424,7 +424,7 @@ class DefaultTrainer(TrainerBase):
         assert (
             _try_get_key(cfg, "optim") is not None
         ), "cfg must contain `optim` namespace"
-        # TODO(l1aoxingyu): Replace after build_optimizer finishing.
+        # TODO(l1aoxingyu): Replace this after build_optimizer finishing.
         optim = cfg.optim
         optim.parameters.model = model
         return instantiate(optim)
@@ -438,7 +438,7 @@ class DefaultTrainer(TrainerBase):
         assert (
             _try_get_key(cfg, "lr_scheduler") is not None
         ), "cfg must contain `lr_scheduler` namespace"
-        # TODO(l1aoxingyu): Replace after build_lr_scheduler finishing.
+        # TODO(l1aoxingyu): Replace this after build_lr_scheduler finishing.
 
         if cfg.train.lr_decay_iter is None:
             cfg.train.lr_decay_iter = cfg.train.train_iter
@@ -450,11 +450,8 @@ class DefaultTrainer(TrainerBase):
         warmup_iters = int(warmup_iters)
 
         lr_scheduler = cfg.lr_scheduler
-        # Setup warmup iters
-        lr_scheduler.warmup_iters = warmup_iters
         # Setup optimizer and decay iters
         lr_scheduler.lrsch_or_optimizer.optimizer = optimizer
-        lr_scheduler.lrsch_or_optimizer.steps = decay_steps
         return instantiate(lr_scheduler)
 
     @classmethod

--- a/libai/trainer/default.py
+++ b/libai/trainer/default.py
@@ -15,29 +15,143 @@
 
 import logging
 import os
-import oneflow as flow
-from oneflow import nn
 from typing import Callable
-from libai.trainer.trainer import TrainerBase, EagerTrainer, GraphTrainer
-from libai.utils import distributed as dist
-from libai.utils.logger import setup_logger
-from libai.utils.events import CommonMetricPrinter, JSONWriter
+
+import oneflow as flow
+from libai.config import LazyConfig, instantiate
 from libai.trainer import hooks
+from libai.trainer.trainer import EagerTrainer, GraphTrainer, TrainerBase
+from libai.utils import distributed as dist
 from libai.utils.checkpoint import Checkpointer
+from libai.utils.events import CommonMetricPrinter, JSONWriter
+from libai.utils.logger import setup_logger
+from omegaconf import OmegaConf
 
 
-def default_setup(cfg):
+def _try_get_key(cfg, *keys, default=None):
+    """
+    Try select keys from cfg until the first key that exists. Otherwise return default.
+    """
+    for k in keys:
+        none = object()
+        p = OmegaConf.select(cfg, k, default=none)
+        if p is not none:
+            return p
+    return default
+
+
+def _highlight(code, filename):
+    try:
+        import pygments
+    except ImportError:
+        return code
+
+    from pygments.formatters import Terminal256Formatter
+    from pygments.lexers import Python3Lexer, YamlLexer
+
+    lexer = Python3Lexer() if filename.endswith(".py") else YamlLexer()
+    code = pygments.highlight(code, lexer, Terminal256Formatter(style="monokai"))
+    return code
+
+
+def _check_batch_size(cfg):
+    if (
+        cfg.train.micro_batch_size is not None
+        and cfg.train.global_batch_size is not None
+    ):
+        if cfg.train.num_accumulation_steps is None:
+            if (
+                cfg.train.global_batch_size
+                % (cfg.train.micro_batch_size * dist.get_data_parallel_size())
+                != 0
+            ):
+                raise ValueError(
+                    f"global_batch_size {cfg.train.global_batch_size} must be divisible by "
+                    f"micro_batch_size * data_parallel_size ({cfg.train.micro_batch_size} * {dist.get_data_parallel_size()})"
+                )
+
+            cfg.train.num_accumulation_steps = cfg.train.global_batch_size // (
+                cfg.train.micro_batch_size * dist.get_data_parallel_size()
+            )
+        else:
+            if (
+                cfg.train.global_batch_size
+                != cfg.train.micro_batch_size
+                * dist.get_data_parallel_size()
+                * cfg.train.num_accumulation_steps
+            ):
+                raise ValueError(
+                    f"global_batch_size {cfg.train.global_batch_size} must equal"
+                    " micro_batch_size * data_parallel_size * num_accumulation_steps"
+                    f" ({cfg.train.micro_batch_size} * {dist.get_data_parallel_size()} * {cfg.train.num_accumulation_steps})"
+                )
+    elif cfg.train.micro_batch_size is not None and cfg.train.global_batch_size is None:
+        if cfg.train.num_accumulation_steps is None:
+            cfg.train.num_accumulation_steps = 1
+
+        cfg.train.global_batch_size = (
+            cfg.train.micro_batch_size
+            * dist.get_data_parallel_size()
+            * cfg.train.num_accumulation_steps
+        )
+    elif cfg.train.micro_batch_size is None and cfg.train.global_batch_size is not None:
+        if cfg.train.num_accumulation_steps is None:
+            cfg.num_accumulation_steps = 1
+
+        if (
+            cfg.train.global_batch_size
+            % (dist.get_data_parallel_size() * cfg.train.num_accumulation_steps)
+            != 0
+        ):
+            raise ValueError(
+                f"global_batch_size {cfg.global_batch_size} must be divisible by "
+                "data_parallel_size * num_accumulation_steps "
+                f"({dist.get_data_parallel_size()} * {cfg.train.num_accumulation_steps})"
+            )
+
+        cfg.train.micro_batch_size = cfg.train.global_batch_size // (
+            dist.get_data_parallel_size() * cfg.train.num_accumulation_steps
+        )
+    else:
+        raise ValueError("micro_batch_size and global_batch_size must be set either")
+
+    assert cfg.train.num_accumulation_steps is not None
+    if cfg.train.num_accumulation_steps > 1 and cfg.data.use_external_dataset:
+        raise ValueError(
+            "num_accumulation_steps couldn't be greater than 1 when use external dataset"
+        )
+
+
+def default_setup(cfg, args):
     """
     Perform some basic common setups at the beginning of a job, including:
-    1. Set up the libai logger
-    2. Log basic information about environment, cmdline arguments, and config
-    3. Backup the config to the output directory
+    1. Check config namespace
+    2. Set up the libai logger
+    3. Log basic information about environment, cmdline arguments, and config
+    4. Setup the distributed environment
+    5. Setup tokenizer if it's NLP related task
+    6. Check batch_size
+    7. Backup the config to the output directory
     Args:
         args (argparse.NameSpace): the command line arguments to be logged
     """
-    output_dir = cfg.output_dir
+    # Check namespace in cfg
+    assert _try_get_key(cfg, "model") is not None, "cfg must contain `model` namespace"
+    assert _try_get_key(cfg, "data") is not None, "cfg must contain `data` namespace"
+    assert _try_get_key(cfg, "train") is not None, "cfg must contain `train` namespace"
+    if not args.eval_only:
+        assert (
+            _try_get_key(cfg, "optim") is not None
+        ), "cfg must contain `optim` namespace when training"
+        assert (
+            _try_get_key(cfg, "lr_scheduler") is not None
+        ), "cfg must contain `lr_scheduler` namespace when training"
+
+    output_dir = _try_get_key(cfg, "train.output_dir")
     if dist.is_main_process() and output_dir:
         os.makedirs(output_dir, exist_ok=True)
+
+    cfg.train.resume = args.resume
 
     rank = dist.get_rank()
     logger = setup_logger(output_dir, distributed_rank=rank)
@@ -47,10 +161,45 @@ def default_setup(cfg):
             rank, dist.get_world_size()
         )
     )
+    logger.info("Command line arguments: " + str(args))
 
-    flow.boxing.nccl.set_fusion_threshold_mbytes(cfg.nccl_fusion_threshold_mb)
-    flow.boxing.nccl.set_fusion_max_ops_num(cfg.nccl_fusion_max_ops)
-    flow.boxing.nccl.enable_use_compute_stream(True)
+    if hasattr(args, "config_file") and args.config_file != "":
+        logger.info(
+            "Contents of args.config_file={}:\n{}".format(
+                args.config_file,
+                _highlight(open(args.config_file, "r").read(), args.config_file),
+            )
+        )
+
+    # Initialize the distributed environment.
+    cfg.train.dist.num_gpus_per_node = args.num_gpus
+    cfg.train.dist.num_nodes = args.num_machines
+    dist.setup_dist_util(_try_get_key(cfg, "train.dist"))
+
+    # Initialize tokenizer
+    if _try_get_key(cfg, "data.tokenizer_setup", default=False):
+        # TODO(l1aoxingyu): add tokenizer
+        # setup_tokenizer(cfg)
+        pass
+
+    _check_batch_size(cfg)
+
+    if dist.is_main_process() and output_dir:
+        # Note: some of our scripts may expect the existence of
+        # config.yaml in output directory
+        path = os.path.join(output_dir, "config.yaml")
+        LazyConfig.save(cfg, path)
+        logger.info("Full config saved to {}".format(path))
+
+    flow.boxing.nccl.set_fusion_threshold_mbytes(
+        _try_get_key(cfg, "train.nccl_fusion_threshold_mb", default=16)
+    )
+    flow.boxing.nccl.set_fusion_max_ops_num(
+        _try_get_key(cfg, "train.nccl_fusion_max_ops", default=24)
+    )
+    flow.boxing.nccl.enable_use_compute_stream(
+        _try_get_key(cfg, "train.enable_use_compute_stream", default=True)
+    )
 
 
 class DefaultTrainer(TrainerBase):
@@ -94,11 +243,12 @@ class DefaultTrainer(TrainerBase):
         super().__init__()
         self.cfg = cfg
         logger = logging.getLogger("libai")
-        if not logger.isEnabledFor(
-            logging.INFO
-        ):  # setup_logger is not called for LibaiLM
+
+        # setup_logger is not called for LiBai
+        if not logger.isEnabledFor(logging.INFO):
             setup_logger()
 
+        # Assume these objects must be constructed in this order.
         self.model = self.build_model(cfg)
         self.optimizer = self.build_optimizer(cfg, self.model)
         self.lr_scheduler = self.build_lr_scheduler(cfg, self.optimizer)
@@ -107,66 +257,66 @@ class DefaultTrainer(TrainerBase):
         # We can later make it checkpoint the stateful hooks
         self.checkpointer = Checkpointer(
             # Assume you want to save checkpoints together with logs/statistics
-            cfg,
             self.model,
-            cfg.output_dir,
+            cfg.train.output_dir,
             optimizer=self.optimizer,
             lr_scheduler=self.lr_scheduler,
         )
 
-        if cfg.load is not None:
-            self.resume_or_load()
-            cfg.iteration = cfg.start_iter
-        else:
-            cfg.iteration = 0
+        # Loading checkpoint before dataloader construction, because
+        # dataloader needs to know the consumed iterations from
+        # the last breakpoint.
+        self.resume_or_load(cfg.train.resume)
+        cfg.train.start_iter = self.start_iter
 
-        # Assume these objects must be constructed in this order.
         (
             self.train_data_iterator,
             self.valid_data_iterator,
             self.test_data_iterator,
-        ) = self.build_train_valid_test_loader_loader(cfg)
+        ) = self.build_train_valid_test_loader(cfg)
 
-        if cfg.mode == "graph":
-            train_graph, eval_graph = self.build_graph(
-                cfg, self.model, self.optimizer, self.lr_scheduler
+        if cfg.graph.enabled:
+            graph_train = self.build_graph(
+                cfg, self.model, self.optimizer, self.lr_scheduler, is_train=True
             )
-            # train_graph.debug(0)
-            self._trainer = GraphTrainer(train_graph, self.train_data_iterator)
-        elif cfg.mode == "eager":
-            self._trainer = EagerTrainer(
-                self.model, self.train_data_iterator, self.optimizer, self.lr_scheduler
-            )
+            graph_eval = self.build_graph(cfg, self.model, is_train=False)
+            # graph_train.debug(0)
+            self._trainer = GraphTrainer(graph_train, self.train_data_iterator)
         else:
-            raise NotImplementedError
+            self._trainer = EagerTrainer(
+                self.model, self.train_data_iterator, self.optimizer
+            )
 
-        self.start_iter = cfg.iteration
-        self.global_batch_size = cfg.global_batch_size
-        self.max_iter = cfg.train_iters
-        self._train_data = None
+        self.global_batch_size = cfg.train.global_batch_size
+        self.max_iter = cfg.train.train_iter
 
         self.register_hooks(self.build_hooks())
 
     def resume_or_load(self, resume=True):
         """
-        If `resume==True` and `cfg.OUTPUT_DIR` contains the last checkpoint (defined by
+        If `resume==True` and `cfg.train.output_dir` contains the last checkpoint (defined by
         a `last_checkpoint` file), resume from the file. Resuming means loading all
         available states (eg. optimizer and scheduler) and update iteration counter
-        from the checkpoint. ``cfg.MODEL.WEIGHTS`` will not be used.
+        from the checkpoint. ``cfg.train.load_weight`` will not be used.
         Otherwise, this is considered as an independent training. The method will load model
-        weights from the file `cfg.MODEL.WEIGHTS` (but will not load other states) and start
+        weights from the file `cfg.train.load_weight` (but will not load other states) and start
         from iteration 0.
         Args:
             resume (bool): whether to do resume or not
         """
-        # The checkpoint stores the training iteration that just finished, thus we start
-        # at the next iteration (or iter zero if there's no checkpoint).
-        checkpoint = self.checkpointer.resume_or_load(self.cfg.load, resume=resume)
-
-        if resume and self.checkpointer.has_checkpoint():
-            self.start_iter = checkpoint.get("iter", -1) + 1
-            # The checkpoint stores the training iteration that just finished, thus we start
-            # at the next iteration (or iter zero if there's no checkpoint).
+        if resume:
+            if self.checkpointer.has_checkpoint():
+                # The checkpoint stores the training iteration that just finished, thus we start
+                # at the next iteration (or iter zero if there's no checkpoint).
+                self.start_iter = (
+                    self.checkpointer.resume_or_load(None, resume=True).get("iter", -1)
+                    + 1
+                )
+            else:
+                # This is considered as an independent training.
+                self.checkpointer.load(self.cfg.train.load_weight, checkpointables=[])
+        else:
+            self.start_iter = 0
 
     def build_hooks(self):
         """
@@ -179,12 +329,14 @@ class DefaultTrainer(TrainerBase):
         ret = [
             hooks.IterationTimer(),
             hooks.LRScheduler(),
-            hooks.PeriodicCheckpointer(self.checkpointer, self.cfg.save_interval),
+            hooks.PeriodicCheckpointer(
+                self.checkpointer, self.cfg.train.checkpointer.period
+            ),
         ]
         if dist.is_main_process():
             # run writers in the end, so that evaluation metrics are written
             ret.append(
-                hooks.PeriodicWriter(self.build_writers(), self.cfg.log_interval)
+                hooks.PeriodicWriter(self.build_writers(), self.cfg.train.log_period)
             )
         return ret
 
@@ -209,7 +361,7 @@ class DefaultTrainer(TrainerBase):
         return [
             # It may not always print what you want to see, since it prints "common" metrics only.
             CommonMetricPrinter(self.global_batch_size, self.max_iter),
-            JSONWriter(os.path.join(self.cfg.output_dir, "metrics.json")),
+            JSONWriter(os.path.join(self.cfg.train.output_dir, "metrics.json")),
         ]
 
     def train(self):
@@ -232,18 +384,26 @@ class DefaultTrainer(TrainerBase):
         It now calls :func:`libai.layers.build_model`.
         Overwrite it if you'd like a different model.
         """
-        # TODO: import build_model from other utils
-        # model = build_model(cfg)
-        model = None
+        model = instantiate(cfg.model)
         logger = logging.getLogger(__name__)
         logger.info("Model:\n{}".format(model))
         return model
 
     @classmethod
-    def build_graph(cls, cfg, model, optimizer, lr_scheduler):
-        # TODO: import build_graph from other utils
-        return None
-        # return build_graph(cfg, model, optimizer, lr_scheduler)
+    def build_graph(cls, cfg, model, optimizer=None, lr_scheduler=None, is_train=True):
+        if is_train:
+            # Set train graph
+            assert optimizer is not None, "optimizer must be set for train graph"
+            assert lr_scheduler is not None, "lr_scheduler must be set for train graph"
+            cfg.graph.num_accumulation_steps = cfg.train.num_accumulation_steps
+            cfg.graph.train.model = model
+            cfg.graph.train.optimizer = optimizer
+            cfg.graph.train.lr_scheduler = lr_scheduler
+            return instantiate(cfg.graph.train)
+        else:
+            # Set eval graph
+            cfg.graph.eval.model = model
+            return instantiate(cfg.graph.eval)
 
     @classmethod
     def build_optimizer(cls, cfg, model):
@@ -253,10 +413,9 @@ class DefaultTrainer(TrainerBase):
         It now calls :func:`libai.solver.build_optimizer`.
         Overwrite it if you'd like a different optimizer.
         """
-        # TODO: import build_optimizer from other utils
-        optimizer = flow.optim.Adam(model.parameters(), lr=0.01)
-        return optimizer
-        # return build_optimizer(cfg, model)
+        optim = cfg.optim
+        optim.parameters.model = model
+        return instantiate(optim)
 
     @classmethod
     def build_lr_scheduler(cls, cfg, optimizer):
@@ -264,21 +423,32 @@ class DefaultTrainer(TrainerBase):
         It now calls :func:`libai.solver.build_lr_scheduler`.
         Overwrite it if you'd like a different scheduler.
         """
-        # TODO: import get_learning_rate_scheduler from other utils
-        lr_scheduler = flow.optim.lr_scheduler.StepLR(optimizer, step_size=1000)
-        return lr_scheduler
-        # return get_learning_rate_scheduler(cfg, optimizer)
+        if cfg.train.lr_decay_iter is None:
+            cfg.train.lr_decay_iter = cfg.train.train_iter
+        decay_steps = int(cfg.train.lr_decay_iter)
+        if cfg.train.lr_warmup_fraction is not None:
+            warmup_iters = cfg.train.lr_warmup_fraction * decay_steps
+        else:
+            warmup_iters = cfg.train.lr_warmup_iters
+        warmup_iters = int(warmup_iters)
+
+        lr_scheduler = cfg.lr_scheduler
+        # Setup warmup iters
+        lr_scheduler.warmup_iters = warmup_iters
+        # Setup optimizer and decay iters
+        lr_scheduler.lrsch_or_optimizer.optimizer = optimizer
+        lr_scheduler.lrsch_or_optimizer.steps = decay_steps
+        return instantiate(lr_scheduler)
 
     @classmethod
-    def build_train_valid_test_loader_loader(cls, cfg):
+    def build_train_valid_test_loader(cls, cfg):
         """
         Returns:
             iterable
-        It now calls :func:`libai.data.build_reid_train_loader`.
+        It now calls :func:`libai.data.build_train_valid_test_loader`.
         Overwrite it if you'd like a different data loader.
         """
         logger = logging.getLogger(__name__)
         logger.info("Prepare training set")
-        # TODO: import build_train_valid_test_data_iterators from other utils
-        return [None], [None], [None]
-        # return build_train_valid_test_data_iterators(cfg)
+        # TODO(l1aoxingyu): add dataloader
+        return None # build_train_valid_test_data_iterators(cfg)

--- a/libai/trainer/default.py
+++ b/libai/trainer/default.py
@@ -21,6 +21,7 @@ import oneflow as flow
 from libai.config import LazyConfig, instantiate
 from libai.trainer import hooks
 from libai.trainer.trainer import EagerTrainer, GraphTrainer, TrainerBase
+from libai.models.build import build_model
 from libai.utils import distributed as dist
 from libai.utils.checkpoint import Checkpointer
 from libai.utils.events import CommonMetricPrinter, JSONWriter
@@ -384,7 +385,7 @@ class DefaultTrainer(TrainerBase):
         It now calls :func:`libai.layers.build_model`.
         Overwrite it if you'd like a different model.
         """
-        model = instantiate(cfg.model)
+        model = build_model(cfg)
         logger = logging.getLogger(__name__)
         logger.info("Model:\n{}".format(model))
         return model
@@ -451,4 +452,4 @@ class DefaultTrainer(TrainerBase):
         logger = logging.getLogger(__name__)
         logger.info("Prepare training set")
         # TODO(l1aoxingyu): add dataloader
-        return None # build_train_valid_test_data_iterators(cfg)
+        return None  # build_train_valid_test_data_iterators(cfg)

--- a/libai/trainer/default.py
+++ b/libai/trainer/default.py
@@ -167,13 +167,13 @@ def default_setup(cfg, args):
     ):
         # This means key(num_gpus_per_node) saved in config is not equal to environment variable.
         # Give user a warning about inconsistent reproduce environment.
-        logger.info(
-            f"Warning! num_gpus_per_node are not equal in cfg and environment variable. {cfg.train.dist.num_gpus_per_node} != {num_gpus_per_node}"
+        logger.warning(
+            f"'train.dist.num_gpus_per_node' are not equal to environment variable. {cfg.train.dist.num_gpus_per_node} != {num_gpus_per_node}"
         )
 
     if _try_get_key(cfg, "train.dist.num_nodes", default=num_nodes) != num_nodes:
-        logger.info(
-            f"Warning! num_nodes are not equal in cfg and environment variable. {cfg.train.dist.num_nodes} != {num_nodes}"
+        logger.warning(
+            f"'train.dist.num_nodes' are not equal to environment variable. {cfg.train.dist.num_nodes} != {num_nodes}"
         )
 
     cfg.train.dist.num_nodes = num_nodes

--- a/libai/trainer/default.py
+++ b/libai/trainer/default.py
@@ -126,27 +126,15 @@ def _check_batch_size(cfg):
 def default_setup(cfg, args):
     """
     Perform some basic common setups at the beginning of a job, including:
-    1. Check config namespace
-    2. Set up the libai logger
-    3. Log basic information about environment, cmdline arguments, and config
-    4. Setup the distributed environment
-    5. Setup tokenizer if it's NLP related task
-    6. Check batch_size
-    7. Backup the config to the output directory
+    1. Set up the libai logger
+    2. Log basic information about environment, cmdline arguments, and config
+    3. Setup the distributed environment
+    4. Setup tokenizer if it's NLP related task
+    5. Check batch_size
+    6. Backup the config to the output directory
     Args:
         args (argparse.NameSpace): the command line arguments to be logged
     """
-    # Check namespace in cfg
-    assert _try_get_key(cfg, "model") is not None, "cfg must contain `model` namespace"
-    assert _try_get_key(cfg, "data") is not None, "cfg must contain `data` namespace"
-    assert _try_get_key(cfg, "train") is not None, "cfg must contain `train` namespace"
-    if not args.eval_only:
-        assert (
-            _try_get_key(cfg, "optim") is not None
-        ), "cfg must contain `optim` namespace when training"
-        assert (
-            _try_get_key(cfg, "lr_scheduler") is not None
-        ), "cfg must contain `lr_scheduler` namespace when training"
 
     output_dir = _try_get_key(cfg, "train.output_dir")
     if dist.is_main_process() and output_dir:
@@ -173,9 +161,28 @@ def default_setup(cfg, args):
         )
 
     # Initialize the distributed environment.
-    cfg.train.dist.num_gpus_per_node = args.num_gpus
+    num_nodes = flow.env.get_node_size()
+    num_gpus_per_node = flow.env.get_world_size() // num_nodes
+
+    if (
+        _try_get_key(cfg, "train.dist.num_gpus_per_node", num_gpus_per_node)
+        != num_gpus_per_node
+    ):
+        # This means key(num_gpus_per_node) saved in config is not equal to environment variable.
+        # Give user a warning about inconsistent reproduce environment.
+        logger.info(
+            f"Warning! num_gpus_per_node are not equal in cfg and environment variable. {cfg.train.dist.num_gpus_per_node} != {num_gpus_per_node}"
+        )
+
+    if _try_get_key(cfg, "train.dist.num_nodes", num_nodes) != num_nodes:
+        logger.info(
+            f"Warning! num_nodes are not equal in cfg and environment variable. {cfg.train.dist.num_nodes} != {num_nodes}"
+        )
+
+    cfg.train.dist_num_gpus_per_node = num_gpus_per_node
     cfg.train.dist.num_nodes = args.num_machines
-    dist.setup_dist_util(_try_get_key(cfg, "train.dist"))
+
+    dist.setup_dist_util(cfg.train.dist)
 
     # Initialize tokenizer
     if _try_get_key(cfg, "data.tokenizer_setup", default=False):
@@ -385,6 +392,9 @@ class DefaultTrainer(TrainerBase):
         It now calls :func:`libai.layers.build_model`.
         Overwrite it if you'd like a different model.
         """
+        assert (
+            _try_get_key(cfg, "model") is not None
+        ), "cfg must contain `model` namespace"
         model = build_model(cfg)
         logger = logging.getLogger(__name__)
         logger.info("Model:\n{}".format(model))
@@ -414,6 +424,10 @@ class DefaultTrainer(TrainerBase):
         It now calls :func:`libai.solver.build_optimizer`.
         Overwrite it if you'd like a different optimizer.
         """
+        assert (
+            _try_get_key(cfg, "optim") is not None
+        ), "cfg must contain `optim` namespace"
+
         optim = cfg.optim
         optim.parameters.model = model
         return instantiate(optim)
@@ -424,6 +438,10 @@ class DefaultTrainer(TrainerBase):
         It now calls :func:`libai.solver.build_lr_scheduler`.
         Overwrite it if you'd like a different scheduler.
         """
+        assert (
+            _try_get_key(cfg, "lr_scheduler") is not None
+        ), "cfg must contain `lr_scheduler` namespace"
+
         if cfg.train.lr_decay_iter is None:
             cfg.train.lr_decay_iter = cfg.train.train_iter
         decay_steps = int(cfg.train.lr_decay_iter)
@@ -449,6 +467,9 @@ class DefaultTrainer(TrainerBase):
         It now calls :func:`libai.data.build_train_valid_test_loader`.
         Overwrite it if you'd like a different data loader.
         """
+        assert (
+            _try_get_key(cfg, "data") is not None
+        ), "cfg must contain `data` namespace"
         logger = logging.getLogger(__name__)
         logger.info("Prepare training set")
         # TODO(l1aoxingyu): add dataloader

--- a/libai/trainer/default.py
+++ b/libai/trainer/default.py
@@ -427,7 +427,7 @@ class DefaultTrainer(TrainerBase):
         assert (
             _try_get_key(cfg, "optim") is not None
         ), "cfg must contain `optim` namespace"
-
+        # TODO(l1aoxingyu): Replace after build_optimizer finishing.
         optim = cfg.optim
         optim.parameters.model = model
         return instantiate(optim)
@@ -441,6 +441,7 @@ class DefaultTrainer(TrainerBase):
         assert (
             _try_get_key(cfg, "lr_scheduler") is not None
         ), "cfg must contain `lr_scheduler` namespace"
+        # TODO(l1aoxingyu): Replace after build_lr_scheduler finishing.
 
         if cfg.train.lr_decay_iter is None:
             cfg.train.lr_decay_iter = cfg.train.train_iter

--- a/libai/trainer/trainer.py
+++ b/libai/trainer/trainer.py
@@ -162,11 +162,7 @@ class TrainerBase:
 
     def after_step(self):
         self.storage.iter = self.iter + 1
-        self.storage.samples = (
-            (self.iter - self.start_iter + 1)
-            * self.cfg.data_parallel_size
-            * self.cfg.micro_batch_size
-        )
+        self.storage.samples = (self.iter + 1) * self.cfg.train.global_batch_size
 
         for h in self._hooks:
             h.after_step()
@@ -184,8 +180,7 @@ class TrainerBase:
             data_time (float): time taken by the dataloader iteration
             prefix (str): prefix for logging keys
         """
-        # TODO: local_only should be False, distributed.py should be fully functional
-        metrics_dict = {k: dist.tton(v, local_only=True) for k, v in loss_dict.items()}
+        metrics_dict = {k: dist.tton(v, local_only=False) for k, v in loss_dict.items()}
         metrics_dict["data_time"] = data_time
 
         # TODO: Gather metrics among all workers for logging
@@ -238,7 +233,7 @@ class EagerTrainer(TrainerBase):
     or write your own training loop.
     """
 
-    def __init__(self, model, data_loader_iter, optimizer, lr_scheduler):
+    def __init__(self, model, data_loader_iter, optimizer):
         """
         Args:
             model: a flow.nn.Module. Takes a data from data_loader and returns a
@@ -255,11 +250,9 @@ class EagerTrainer(TrainerBase):
 
         model.train()
 
-        self.model = model.to("cuda")
+        self.model = model
         self._data_loader_iter = iter(data_loader_iter)
         self.optimizer = optimizer
-        self.lr_scheduler = lr_scheduler
-        self.mode = "eager"
 
     def run_step(self, get_batch: Callable):
         """
@@ -269,7 +262,7 @@ class EagerTrainer(TrainerBase):
         start = time.perf_counter()
 
         # If you want to do something with the data, you can wrap the dataloader.
-        data = get_batch(self._data_loader_iter, self.mode)
+        data = get_batch(self._data_loader_iter)
         data_time = time.perf_counter() - start
 
         # If you want to do something with the losses, you can wrap the model.
@@ -299,7 +292,6 @@ class GraphTrainer(TrainerBase):
         graph.model.train()
         self._data_loader_iter = iter(data_loader_iter)
         self.graph = graph
-        self.mode = "graph"
 
     def run_step(self, get_batch: Callable):
         """
@@ -311,7 +303,7 @@ class GraphTrainer(TrainerBase):
         start = time.perf_counter()
 
         # If you want to do something with the data, you can wrap the dataloader.
-        data = get_batch(self._data_loader_iter, self.mode)
+        data = get_batch(self._data_loader_iter)
         data_time = time.perf_counter() - start
 
         # If you want to do something with the losses, you can wrap the model.

--- a/libai/utils/checkpoint.py
+++ b/libai/utils/checkpoint.py
@@ -56,7 +56,6 @@ class Checkpointer(object):
 
     def __init__(
         self,
-        cfg,
         model: nn.Module,
         save_dir: str = "",
         *,
@@ -74,7 +73,6 @@ class Checkpointer(object):
                 example, it can be used like
                 `Checkpointer(model, "dir", optimizer=optimizer)`.
         """
-        self.cfg = cfg
         self.model = model
         self.checkpointables = copy.copy(checkpointables)
         self.logger = logging.getLogger(__name__)
@@ -114,12 +112,7 @@ class Checkpointer(object):
             if self.path_manager.exists(save_file):
                 self.path_manager.mkdirs(save_file)
 
-            if self.cfg.mode == "graph":
-                flow.save(data[save_name], save_file, consistent_dst_rank=0)
-            elif self.cfg.mode == "eager":
-                flow.save(data[save_name], save_file)
-            else:
-                raise NotImplementedError
+            flow.save(data[save_name], save_file, consistent_dst_rank=0)
 
         self.tag_last_checkpoint(basename)
 
@@ -298,7 +291,7 @@ class Checkpointer(object):
                     "Unsupported type found in checkpoint! {}: {}".format(k, type(v))
                 )
             # If it's local tensor, convert it to consistent tensor.
-            if not v.is_consistent and self.cfg.mode == "graph":
+            if not v.is_consistent:
                 if k in self.model.state_dict():
                     model_v = self.model.state_dict()[k]
                     state_dict[k] = v.to_consistent(

--- a/libai/utils/events.py
+++ b/libai/utils/events.py
@@ -166,7 +166,6 @@ class CommonMetricPrinter(EventWriter):
             data_time = None
 
         eta_string = None
-        throughput = None
         try:
             iter_time = storage.history("time").global_avg()
             eta_seconds = storage.history("time").median(1000) * (
@@ -174,8 +173,6 @@ class CommonMetricPrinter(EventWriter):
             )
             storage.put_scalar("eta_seconds", eta_seconds, smoothing_hint=False)
             eta_string = str(datetime.timedelta(seconds=int(eta_seconds)))
-            throughput = self._batch_size / iter_time
-            storage.put_scalar("throughputs", throughput, smoothing_hint=False)
         except KeyError:
             iter_time = None
             # estimate eta on our own - more noisy
@@ -200,7 +197,7 @@ class CommonMetricPrinter(EventWriter):
 
         # NOTE: max_mem is parsed by grep in "dev/parse_results.sh"
         self.logger.info(
-            " {eta}{iter}  {sample}  {losses}  {time}{data_time} {throughput} lr: {lr}  {memory}".format(
+            " {eta}{iter}  {sample}  {losses}  {time}{data_time}  lr: {lr}  {memory}".format(
                 eta=f"eta: {eta_string}  " if eta_string else "",
                 iter=f"iteration: {iteration}/{self._max_iter}",
                 sample=f"consumed samples: {consumed_samples}",
@@ -211,14 +208,13 @@ class CommonMetricPrinter(EventWriter):
                         if "loss" in k
                     ]
                 ),
-                time="time: {:.4f}  ".format(iter_time)
+                time="time: {:.4f}({:.2f})  ".format(
+                    iter_time, self._batch_size / iter_time
+                )
                 if iter_time is not None
                 else "",
-                data_time="data_time: {:.4f}  ".format(data_time)
+                data_time="data_time: {:.4f}".format(data_time)
                 if data_time is not None
-                else "",
-                throughput="tpt: {:.1f} samples/s ".format(throughput)
-                if throughput is not None
                 else "",
                 lr=lr,
                 memory="max_mem: {:.0f}M".format(max_mem_mb)

--- a/tests/layers/test_trainer_model.py
+++ b/tests/layers/test_trainer_model.py
@@ -35,15 +35,14 @@ class demo_model(nn.Module):
 
 def build_model(cfg):
     model = demo_model()
-    if cfg.mode == "graph":
-        placement = flow.env.all_device_placement("cuda")
-        model = model.to_consistent(placement=placement, sbp=flow.sbp.broadcast)
+    placement = flow.env.all_device_placement("cuda")
+    model = model.to_consistent(placement=placement, sbp=flow.sbp.broadcast)
     return model
 
 
 def build_graph(cfg, model, optimizer, lr_scheduler, fp16=False):
     class GraphModel(nn.Graph):
-        def __init__(self, cfg, model, optimizer, lr_scheduler, fp16=False):
+        def __init__(self, model, optimizer, lr_scheduler, fp16=False):
             super().__init__()
             self.model = model
             self.add_optimizer(optimizer, lr_sch=lr_scheduler)
@@ -64,5 +63,7 @@ def build_graph(cfg, model, optimizer, lr_scheduler, fp16=False):
             loss.backward()
             return loss
 
-    graph_model = GraphModel(cfg, model, optimizer, lr_scheduler, fp16=False)
-    return graph_model, None
+    if optimizer:
+        return GraphModel(model, optimizer, lr_scheduler, fp16=fp16)
+    else:
+        return None

--- a/tools/pretrain_bert.py
+++ b/tools/pretrain_bert.py
@@ -1,0 +1,77 @@
+# coding=utf-8
+# Copyright 2021 The OneFlow Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+
+import oneflow as flow
+
+sys.path.append(".")
+from libai.config import LazyConfig, default_argument_parser
+from libai.utils import distributed as dist
+from libai.utils.checkpoint import Checkpointer
+
+from libai.trainer import DefaultTrainer, default_setup
+
+
+def get_batch(data_iterator):
+    """Build the batch for Bert model."""
+
+    assert data_iterator is not None, "data iterator is None!"
+    data = next(data_iterator)
+
+    input_placement = dist.get_layer_placement(0)
+    label_placement = dist.get_layer_placement(-1)
+    sbp = dist.get_nd_sbp([flow.sbp.split(0), flow.sbp.broadcast])
+
+    def to_consistent(tensor, placement):
+        tensor = tensor.to_consistent(placement, sbp)
+        return tensor
+
+    # Unpack.
+    tokens = to_consistent(data["text"].long(), input_placement)
+    types = to_consistent(data["types"].long(), input_placement)
+    padding_mask = to_consistent(data["padding_mask"].long(), input_placement)
+    sentence_order = to_consistent(data["is_random"].long(), label_placement)
+    loss_mask = to_consistent(data["loss_mask"].float(), label_placement)
+    lm_labels = to_consistent(data["labels"].long(), label_placement)
+
+    return tokens, padding_mask, types, sentence_order, lm_labels, loss_mask
+
+
+class Trainer(DefaultTrainer):
+    def run_step(self):
+        return super().run_step(get_batch)
+
+
+def main(args):
+    cfg = LazyConfig.load(args.config_file)
+    cfg = LazyConfig.apply_overrides(cfg, args.opts)
+    default_setup(cfg, args)
+
+    if args.eval_only:
+        model = Trainer.build_model(cfg)
+        Checkpointer(model, save_dir=cfg.train.output_dir).resume_or_load(
+            cfg.train.load_weight, resume=args.resume
+        )
+        graph = Trainer.build_graph(cfg, model, is_train=False)
+        res = Trainer.test(cfg, graph)
+
+    trainer = Trainer(cfg)
+    return trainer.train()
+
+
+if __name__ == "__main__":
+    args = default_argument_parser().parse_args()
+    main(args)

--- a/tools/train.sh
+++ b/tools/train.sh
@@ -9,4 +9,4 @@ PORT=${PORT:-29500}
 python3 -m oneflow.distributed.launch \
 --nproc_per_node $GPUS --nnodes $NODE --node_rank $NODE_RANK --master_addr $PORT \
 tools/pretrain_bert.py \
---config-file $CONFIG --num-gpus $GPUS ${@:3}
+--config-file $CONFIG ${@:3}

--- a/tools/train.sh
+++ b/tools/train.sh
@@ -4,9 +4,9 @@ CONFIG=$1
 GPUS=$2
 NODE=${NODE:-1}
 NODE_RANK=${NODE_RANK:-0}
-PORT=${PORT:-29500}
+ADDR=${ADDR:-127.0.0.1}
 
 python3 -m oneflow.distributed.launch \
---nproc_per_node $GPUS --nnodes $NODE --node_rank $NODE_RANK --master_addr $PORT \
+--nproc_per_node $GPUS --nnodes $NODE --node_rank $NODE_RANK --master_addr $ADDR \
 tools/pretrain_bert.py \
 --config-file $CONFIG ${@:3}

--- a/tools/train.sh
+++ b/tools/train.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+CONFIG=$1
+GPUS=$2
+NODE=${NODE:-1}
+NODE_RANK=${NODE_RANK:-0}
+PORT=${PORT:-29500}
+
+python3 -m oneflow.distributed.launch \
+--nproc_per_node $GPUS --nnodes $NODE --node_rank $NODE_RANK --master_addr $PORT \
+tools/pretrain_bert.py \
+--config-file $CONFIG --num-gpus $GPUS ${@:3}


### PR DESCRIPTION
# 配置系统

目前的配置系统基于下面4个特点进行构建：

- 生成的配置文件可以序列化和反序列化，这样的好处有两个：1. 用户可以通过 diff config 轻松获得两次训练的配置差异；2. 直接 load config 便能复现别人的结果，能够节省大量沟通的时间成本；
- 配置系统层次清晰，比如模型结构相关的参数、网络训练的超参以及数据读取的参数能够清晰的分开；
- 参数在配置之后是可修改的，因为有的时候需要根据数据集的 size 再动态设置训练的 iters 等，这就需要用户定义好配置之后，参数可以再次被修改；
- 用户可以灵活增加配置参数而不需要侵入式修改 libai 的内部代码，希望用户可以将 libai 作为一个 lib 进行使用，而不是 clone 之后在上面修改；



## 两种配置方式

最终选择基于 LazyConfig 来构建 libai 项目，提供两种风格的配置文件，一种是注册+解析的方式，一种是 LazyCall 的方式。注册+解析是为了兼容之前一些项目的构建习惯，LazyCall 则是另外一种全新的配置系统思路，比注册+解析更灵活。

注册+解析是之前比较常用的配置方式，通过装饰器将可能会用到的对象注册好，随后便可以通过名字去获取对应的对象，在实例化阶段将参数传入。这种方式的一个问题在于额外引入的注册机制并不够方便，只有注册过的对象才能获取，而我们显然不能对所有代码中的对象都进行注册，一些其他库的对象也无法注册；另外一个问题在于不同用户需要使用对方注册的内容时也不够方便。

LazyCall 是另外一种类型的配置方式，不需要利用注册系统，利用 python 配置文件的特性将需要的模块直接 import，利用延后初始化的特性直接传参，在实例化之前可以进行任意参数的修改，最终在需要的时候进行实例化。



## 配置文件语法

上述两种方式都是采用了 python 文件来构建，因为序列化和反序列化的问题，没有采用命令行传参。另外考虑到 yaml 文件不够灵活，而 python 不仅语法更熟悉，而且可以内置一些计算，更复杂的嵌套和数据类型。

最终生成的配置文件会保存成一个 yaml 文件，如果要复现实验结果，只需要将 `config.yaml` 作为配置文件传到系统中。

不同类型的参数可以放在不同的地方实现参数隔离，比如

```python
# data.py
data = dict(
    # Pad the vocab size to be divisible by this value
    # This is added for computational efficiency reasons.
    make_vocab_size_divisible_by=128,
    data_path=[
        "/workspace/idea_model/idea_bert/output_data/loss_compara_content_sentence"
    ],
    split="949,50,1",
    vocab_file="/workspace/idea_model/idea_bert/bert-base-chinese-vocab.txt",
    ...
)

# bert.py
model = dict(
    model_name="BertModel",
    
  	model_cfg=dict(
        vocab_size=30522,
        hidden_size=768,
        hidden_layers=24,
        num_attention_heads=12,
      ...
    )
)

# gpt.py
model = dict(
		model_name="GPT_2",
  
  	model_cfg=dict(
    		vocab_size=30522,
      	hidden_size=768,
      ...
    )
)

# bert_large.py
from bert.py import model
model.model_cfg.hidden_size = 1537
```

通过这种方式，需要使用哪个模型作为模板可以直接 import 对应的模型配置文件，然后再做对应的修改，如果是一个全新的模型，也可以根据模型本身的参数完全重写一套，保证配置文件中的参数名字和模型定义的参数名字一致就可以了。

要查看内置模型需要的参数也可以直接访问对应模型的配置文件，不需要到模型定义的代码处进行查看。最后序列化会只保存使用到的配置文件参数。



## 模型的配置文件举例

下面分别用上述提到的两种配置方式对 bert 模型构建进行举例说明。

### 采用注册+解析的方式

```python
# configs/model/bert.py

# registry + arguments parse
model = dict(
    model_name="BertModel",
    
  	model_cfg=dict(
        vocab_size=30522,
        hidden_size=768,
        hidden_layers=24,
        num_attention_heads=12,
        intermediate_size=4096,
        hidden_dropout_prob=0.1,
        attention_probs_dropout_prob=0.1,
        max_position_embeddings=512,
        num_tokentypes=2,
        add_pooling_layer=True,
        initializer_range=0.02,
        layernorm_eps=1e-5,
        bias_gelu_fusion=True,
        bias_dropout_fusion=True,
        scale_mask_softmax_fusion=False,
        apply_query_key_layer_scaling=True,
    ),
)

# modify default arguments
model.model_cfg.vocab_size = 3000
```

序列化后的 config.yaml 文件，支持反序列化之后进行构建。

```yaml
# config.yaml
model:
  model_name: BertModel
  model_cfg: {add_pooling_layer: true, apply_query_key_layer_scaling: true, attention_probs_dropout_prob: 0.1, bias_dropout_fusion: true, bias_gelu_fusion: true, hidden_dropout_prob: 0.1, hidden_layers: 24, hidden_size: 768, initializer_range: 0.02, intermediate_size: 4096, layernorm_eps: 1.0e-05, max_position_embeddings: 512, num_attention_heads: 12, num_tokentypes: 2, scale_mask_softmax_fusion: false, vocab_size: 30522}
```

### LazyCall

```python
# configs/model/bert.py

# LazyCall
from libai.config import LazyCall
from libai.models import BertModel

cfg = dict(
    vocab_size=30522,
    hidden_size=768,
    hidden_layers=24,
    num_attention_heads=12,
    intermediate_size=4096,
    hidden_dropout_prob=0.1,
    attention_probs_dropout_prob=0.1,
    max_position_embeddings=512,
    num_tokentypes=2,
    add_pooling_layer=True,
    initializer_range=0.02,
    layernorm_eps=1e-5,
    bias_gelu_fusion=True,
    bias_dropout_fusion=True,
    scale_mask_softmax_fusion=False,
    apply_query_key_layer_scaling=True,
)

model = LazyCall(BertModel)(cfg=cfg)

# modify default arguments
model.cfg.vocab_size = 3000
```

序列化之后的配置文件。

```yaml
model:
  _target_: libai.models.BertModel
  cfg: {add_pooling_layer: true, apply_query_key_layer_scaling: true, attention_probs_dropout_prob: 0.1, bias_dropout_fusion: true, bias_gelu_fusion: true, hidden_dropout_prob: 0.1, hidden_layers: 24, hidden_size: 768, initializer_range: 0.02, intermediate_size: 4096, layernorm_eps: 1.0e-05, max_position_embeddings: 512, num_attention_heads: 12, num_tokentypes: 2, scale_mask_softmax_fusion: false, vocab_size: 30522}
```

上面两种方法最终获得的保存结果是类似的，唯一的区别是 LazyCall 可以更好的定位到使用的模型是 `libai.models.BertModel` 而注册+解析的方式只能获得一个模型名称。



## 总结

有了标准的注册+解析的配置文件机制，最后再讲一下为什么我们还想额外引入 LazyCall 的机制：

1. 使用 LazyCall 的对象构建是与**配置系统无关**的，其只是常见的 python 函数和类，这意味着我们的配置文件甚至可以被其他的库引入，比如

   ```python
   linear1d = {"_target_": "libai.layers.Linear", "in_features": 100, "out_features": 200, "parallel": "col"}
   linear = {"_target_": "flow.nn.Linear", "in_features": 100, "out_features": 200}
   ```

   这个配置文件可以直接在其他的库进行实例化而不依赖于使用 cfg 文件。

2. 通过阅读配置结果，可以更**清晰地**看到调用了哪个类，以及哪个函数，他们分别使用的参数是什么。
3. `cfg` 中的 key 并不需要提前被定义，使用 LazyCall 给了我们机会在对象和函数被实例化之前有机会能修改他的值，这给了我们更多的**灵活性**。

4. LazyCall 和注册+解析是**兼容**的，同时给了我们更多的可能性去探索可编程式的配置文件。