### PR TITLE
configure default distributed env

### DIFF
--- a/configs/bert_large_pretrain.py
+++ b/configs/bert_large_pretrain.py
@@ -11,9 +11,6 @@ model.cfg.num_attention_heads = 16
 model.cfg.hidden_size = 768
 model.cfg.hidden_layers = 8
 
-# Set pipeline layers for paralleleism
-train.dist.pipeline_num_layers = model.cfg.hidden_layers
-
 train.micro_batch_size = 16
 
 # Set fp16 ON

--- a/libai/config/__init__.py
+++ b/libai/config/__init__.py
@@ -16,7 +16,7 @@
 from .lazy import LazyCall, LazyConfig
 from .instantiate import instantiate
 from .arguments import default_argument_parser
-from .config import configurable
+from .config import configurable, try_get_key
 
 __all__ = [
     "LazyCall",
@@ -24,4 +24,5 @@ __all__ = [
     "instantiate",
     "default_argument_parser",
     "configurable",
+    "try_get_key",
 ]

--- a/libai/config/config.py
+++ b/libai/config/config.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from omegaconf import OmegaConf
 import functools
 import inspect
 
@@ -155,3 +156,15 @@ def _called_with_cfg(*args, **kwargs):
     # `from_config`'s first argument is forced to be "cfg".
     # So the above check covers all cases.
     return False
+
+
+def try_get_key(cfg, *keys, default=None):
+    """
+    Try select keys from cfg until the first key that exists. Otherwise return default.
+    """
+    for k in keys:
+        none = object()
+        p = OmegaConf.select(cfg, k, default=none)
+        if p is not none:
+            return p
+    return default

--- a/libai/utils/distributed.py
+++ b/libai/utils/distributed.py
@@ -13,7 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import oneflow as flow
+
+from libai.config import try_get_key
+
+logger = logging.getLogger(__name__)
 
 _DIST_UTIL = None
 
@@ -31,17 +36,54 @@ def _merge_devices(devices):
 
 class _DistributeUtil(object):
     def __init__(self, cfg):
+
+        self._init_distributed_env(cfg)
         self._init_parallel_size(cfg)
         self._init_placement_group(cfg)
         self._init_parallel_hierarchy()
 
+    def _init_distributed_env(self, cfg):
+        """Initialize the distributed environment."""
+
+        num_nodes = get_num_nodes()
+        num_gpus_per_node = get_world_size() // num_nodes
+
+        if (
+            try_get_key(cfg, "num_gpus_per_node", default=num_gpus_per_node)
+            != num_gpus_per_node
+        ):
+            # This means key(num_gpus_per_node) saved in config is not equal to environment variable.
+            # Give user a warning about inconsistent reproduce environment.
+            logger.warning(
+                f"'train.dist.num_gpus_per_node' are not equal to environment variable. {cfg.num_gpus_per_node} != {num_gpus_per_node}"
+            )
+
+        if try_get_key(cfg, "num_nodes", default=num_nodes) != num_nodes:
+            logger.warning(
+                f"'train.dist.num_nodes' are not equal to environment variable. {cfg.num_nodes} != {num_nodes}"
+            )
+
+        if try_get_key(cfg, "pipeline_num_layers") is None:
+            logger.warning(
+                "Please set `train.dist.pipeline_num_layers` if you want to train with "
+                "pipeline parallelism, otherwise just ignore it."
+            )
+            cfg.pipeline_num_layers = 10000
+
+        # Set the actual value to config
+        cfg.num_nodes = num_nodes
+        cfg.num_gpus_per_node = num_gpus_per_node
+
+        self._num_nodes = num_nodes
+        self._num_gpus_per_node = num_gpus_per_node
+        self._world_size = num_gpus_per_node * num_nodes
+
     def _init_parallel_size(self, cfg):
-        self._world_size = cfg.num_gpus_per_node * cfg.num_nodes
 
         # tensor parallel size
-        self._tensor_parallel_size = min(cfg.tensor_parallel_size, self._world_size)
-        assert self._world_size % self._tensor_parallel_size == 0, (
-            f"world size ({self._world_size}) is not divisible by"
+        self._tensor_parallel_size = min(cfg.tensor_parallel_size, self.world_size)
+        assert self.world_size % self._tensor_parallel_size == 0, (
+            f"world size ({self.world_size}) is not divisible by"
             f" tensor parallel size ({self._tensor_parallel_size})"
         )
         # Set the actual tensor parallel size to cfg
@@ -49,7 +91,7 @@ class _DistributeUtil(object):
 
         # pipeline parallel size
         self._pipeline_parallel_size = min(
-            cfg.pipeline_parallel_size, self._world_size // cfg.tensor_parallel_size
+            cfg.pipeline_parallel_size, self.world_size // cfg.tensor_parallel_size
         )
         # Set the actual pipeline parallel size to cfg
         cfg.pipeline_parallel_size = self._pipeline_parallel_size
@@ -58,27 +100,27 @@ class _DistributeUtil(object):
             self._pipeline_parallel_size * self._tensor_parallel_size
         )
 
-        assert self._world_size % self._model_parallel_size == 0, (
-            f"world size ({self._world_size}) is not divisible by"
+        assert self.world_size % self._model_parallel_size == 0, (
+            f"world size ({self.world_size}) is not divisible by"
             f" tensor model parallel size ({self._tensor_parallel_size}) times"
             f" pipeline model parallel size ({self._pipeline_parallel_size})"
         )
 
         # data parallel size
-        self._data_parallel_size = self._world_size // self._model_parallel_size
+        self._data_parallel_size = self.world_size // self._model_parallel_size
         # Set the actual data parallel size to cfg
         cfg.data_parallel_size = self._data_parallel_size
 
     def _init_placement_group(self, cfg):
-        node_ids = [i // cfg.num_gpus_per_node for i in range(self._world_size)]
-        device_ids = list(range(cfg.num_gpus_per_node)) * cfg.num_nodes
+        node_ids = [i // self.num_gpus_per_node for i in range(self.world_size)]
+        device_ids = list(range(self.num_gpus_per_node)) * self.num_nodes
 
         # [(0, 0), (0, 1), (0, 2), (0, 3), (1, 0), (1, 1), (1, 2), (1, 3)]
         devices = [(n, d) for n, d in zip(node_ids, device_ids)]
-        num_devices_per_stage = self._world_size // self._pipeline_parallel_size
+        num_devices_per_stage = self.world_size // self._pipeline_parallel_size
         stages_devices = [
             _merge_devices(devices[i : (i + num_devices_per_stage)])
-            for i in range(0, self._world_size, num_devices_per_stage)
+            for i in range(0, self.world_size, num_devices_per_stage)
         ]
 
         assert cfg.pipeline_num_layers % self._pipeline_parallel_size == 0, (
@@ -102,6 +144,18 @@ class _DistributeUtil(object):
             )
         else:
             self._parallel_hierarchy = None
+
+    @property
+    def num_nodes(self):
+        return self._num_nodes
+
+    @property
+    def num_gpus_per_node(self):
+        return self._num_gpus_per_node
+
+    @property
+    def world_size(self):
+        return self._world_size
 
     @property
     def parallel_hierarchy(self):
@@ -149,9 +203,21 @@ def setup_dist_util(cfg):
 
 def get_dist_util():
     global _DIST_UTIL
-    assert (
-        _DIST_UTIL is not None
-    ), "Please setup distributed utils first by invoking `setup_dist_util`!"
+    if _DIST_UTIL is None:
+        logger.warning(
+            "Distributed env is not set up, configure it by default (single node, single gpu)."
+        )
+        from omegaconf import DictConfig
+
+        setup_dist_util(
+            DictConfig(
+                dict(
+                    data_parallel_size=1,
+                    tensor_parallel_size=1,
+                    pipeline_parallel_size=1,
+                )
+            )
+        )
     return _DIST_UTIL
 
 
@@ -167,9 +233,10 @@ def get_layer_placement(layer_idx, device_type="cuda"):
 def get_all_placement(device_type="cuda"):
     dist_util = get_dist_util()
 
-    # FIXME(l1aoxingyu): fix this when training with multi-node
     return flow.placement(
-        device_type, {0: range(get_world_size())}, dist_util.parallel_hierarchy
+        device_type,
+        {i: range(dist_util.num_gpus_per_node) for i in range(dist_util.num_nodes)},
+        dist_util.parallel_hierarchy,
     )
 
 
@@ -237,6 +304,10 @@ def is_last_process() -> bool:
 
 def get_world_size():
     return flow.env.get_world_size()
+
+
+def get_num_nodes():
+    return flow.env.get_node_size()
 
 
 def ttol(tensor, pure_local=False):


### PR DESCRIPTION
当用户直接调用 libai 里面的模型或者 layers 进行使用的时候，因为这些 layers 中的 parameters 都是 consistent tensor，所以需要指定 sbp 和 placement，比如

```python
self.weight = nn.Parameter(
            flow.empty(
                (num_embeddings, embedding_dim),
                dtype=flow.float32,
                placement=dist.get_layer_placement(0),
                sbp=dist.get_nd_sbp([flow.sbp.broadcast, flow.sbp.broadcast]),
            )
        )
```

其中会调用 `libai.utils.distributed` 里面的 `get_layer_placement` 和 `get_nd_sbp`，这两个函数需要知晓分布式环境初始化才能调用。

如果用户需要使用 libai 里面的 models 或者 layers 构建完整的训练流程，那么可以手动通过 `dist.setup_dist_util(cfg)` 的方式初始化分布式信息，随后即可正常构建模型，这个也已经在内置的 `default_setup` 中自动完成，无需用户手动调用。

另外一种情况是用户想初始化一个 layers 或者一个 tiny model 做一个简单的测试，那么目前的流程仍然需要他写一个分布式配置，在这个情况下这种方式并不够友好，我们期望如果用户不想管分布式相关的内容，只想初始化模型查看结构，或者验证前向的一些计算流程，就帮助用户创建一个默认的单机单卡的分布式环境。