### PR TITLE
add error info for DistTensorData

### DIFF
--- a/libai/data/structures.py
+++ b/libai/data/structures.py
@@ -58,7 +58,7 @@ class DistTensorData:
             raise TypeError(
                 "DistTensorData.tensor must be a flow.Tensor, but got {}. "
                 "Please check the return values of `__getitem__` in dataset.".format(
-                    distTensor_lists[0].tensor
+                    type(distTensor_lists[0].tensor)
                 )
             )
 

--- a/libai/data/structures.py
+++ b/libai/data/structures.py
@@ -66,7 +66,9 @@ class DistTensorData:
         if len(distTensor_lists) == 1:
             # TODO(l1aoxingyu): add inplace unsqueeze
             # distTensor_lists[0].tensor.unsqueeze_(0)  # add batch dim
-            distTensor_lists[0].tensor = distTensor_lists[0].tensor.unsqueeze(0)  # add batch dim
+            distTensor_lists[0].tensor = distTensor_lists[0].tensor.unsqueeze(
+                0
+            )  # add batch dim
             return distTensor_lists[0]
 
         tensor_size = distTensor_lists[0].tensor.size()

--- a/libai/data/structures.py
+++ b/libai/data/structures.py
@@ -53,17 +53,25 @@ class DistTensorData:
         self.tensor = self.tensor.to_consistent(sbp=self.sbp, placement=self.placement)
 
     @staticmethod
-    def stack(metadata_lists: List["DistTensorData"]) -> "DistTensorData":
-        assert len(metadata_lists) > 0
-        if len(metadata_lists) == 1:
-            metadata_lists[0].tensor.unsqueeze_(0)  # add batch dim
-            return metadata_lists[0]
+    def stack(distTensor_lists: List["DistTensorData"]) -> "DistTensorData":
+        if not isinstance(distTensor_lists[0].tensor, flow.Tensor):
+            raise TypeError(
+                "DistTensorData.tensor must be a flow.Tensor, but got {}. "
+                "Please check the return values of `__getitem__` in dataset.".format(
+                    distTensor_lists[0].tensor
+                )
+            )
 
-        tensor_size = metadata_lists[0].tensor.size()
-        sbp_list = metadata_lists[0].sbp_list
-        placement_idx = metadata_lists[0].placement_idx
+        assert len(distTensor_lists) > 0
+        if len(distTensor_lists) == 1:
+            distTensor_lists[0].tensor.unsqueeze_(0)  # add batch dim
+            return distTensor_lists[0]
+
+        tensor_size = distTensor_lists[0].tensor.size()
+        sbp_list = distTensor_lists[0].sbp_list
+        placement_idx = distTensor_lists[0].placement_idx
         tensors = []
-        for data in metadata_lists:
+        for data in distTensor_lists:
             assert (
                 data.tensor.size() == tensor_size
             ), f"tensor shape is not equal, {data.tensor.size()} != {tensor_size}"

--- a/libai/data/structures.py
+++ b/libai/data/structures.py
@@ -64,7 +64,9 @@ class DistTensorData:
 
         assert len(distTensor_lists) > 0
         if len(distTensor_lists) == 1:
-            distTensor_lists[0].tensor.unsqueeze_(0)  # add batch dim
+            # TODO(l1aoxingyu): add inplace unsqueeze
+            # distTensor_lists[0].tensor.unsqueeze_(0)  # add batch dim
+            distTensor_lists[0].tensor = distTensor_lists[0].tensor.unsqueeze(0)  # add batch dim
             return distTensor_lists[0]
 
         tensor_size = distTensor_lists[0].tensor.size()

--- a/libai/trainer/default.py
+++ b/libai/trainer/default.py
@@ -355,6 +355,9 @@ class DefaultTrainer(TrainerBase):
         If you want to do something with batched data before model, (e.g. mixup),
         you can rewrite this function.
         """
+        if isinstance(data, flow.utils.data._utils.worker.ExceptionWrapper):
+            data.reraise()
+
         ret_dict = {}
         ret_list = []
         for key, value in data.get_fields().items():


### PR DESCRIPTION
### 增加一个更友好的报错提示

有时在 `__getitem__` 返回值的时候，对 label 会忘记处理成一个 tensor，比如

```python
def __getitem__(self, index: int):
	img, target = super().__getitem__(index)
	data_sample = Instance(
	images = DistTensorData(img, placement_idx=0), 
	# targets = DistTensorData(flow.tensor(target, dtype=flow.long), placement_idx=-1) 正确形式
	targets = DistTensorData(target, placement_idx=-1) # 错误形式
  )
  return data_sample
```



之前的代码会出现下面的错误提示，并没有给出有意义的报错信息

```python
AttributeError: 'int' object has no attribute 'size'
```



增加新的报错信息之后，错误信息如下

```python
TypeError: DistTensorData.tensor must be a flow.Tensor, but got 5. Please check the return values of `__getitem__` in dataset.
```

