### PR TITLE
change batchsize config

### DIFF
--- a/configs/common/data/nlp_data.py
+++ b/configs/common/data/nlp_data.py
@@ -27,5 +27,5 @@ dataloader.test = [
     ),
     LazyCall(build_nlp_test_loader)(
         dataset=LazyCall(DemoNlpDataset)(data_root="test2",)
-    )
+    ),
 ]

--- a/configs/common/data/nlp_data.py
+++ b/configs/common/data/nlp_data.py
@@ -18,15 +18,14 @@ dataloader.train = LazyCall(build_nlp_train_val_test_loader)(
     ],
     splits=[[949.0, 50.0, 1.0], [900.0, 99.0, 1.0]],
     weights=[0.5, 0.5],
-    batch_size=32,
     num_workers=4,
 )
 
 dataloader.test = [
     LazyCall(build_nlp_test_loader)(
-        dataset=LazyCall(DemoNlpDataset)(data_root="test1",), batch_size=32,
+        dataset=LazyCall(DemoNlpDataset)(data_root="test1",)
     ),
     LazyCall(build_nlp_test_loader)(
-        dataset=LazyCall(DemoNlpDataset)(data_root="test2",), batch_size=32,
-    ),
+        dataset=LazyCall(DemoNlpDataset)(data_root="test2",)
+    )
 ]

--- a/configs/common/train.py
+++ b/configs/common/train.py
@@ -2,7 +2,8 @@
 train = dict(
     output_dir="./demo_output/test_config",
 
-    micro_batch_size=32,
+    train_micro_batch_size=32,
+    test_micro_batch_size=32,
     global_batch_size=None,
     num_accumulation_steps=None,
 

--- a/libai/data/build.py
+++ b/libai/data/build.py
@@ -44,7 +44,7 @@ def build_nlp_train_val_test_loader(
         dataset = list(dataset)
     elif not isinstance(dataset, list):
         dataset = [dataset]
-        
+
     assert len(dataset) == len(splits), "datasets length must equal splits length"
     assert len(dataset) == len(weights), "datasets length must equal weights length"
 

--- a/libai/data/build.py
+++ b/libai/data/build.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import omegaconf
 import oneflow.utils.data as flowdata
 from oneflow.utils.data.dataset import ConcatDataset
 
@@ -39,7 +40,10 @@ def build_nlp_train_val_test_loader(
     """
     # TODO: add input type
 
-    dataset = list(dataset)
+    if isinstance(dataset, omegaconf.listconfig.ListConfig):
+        dataset = list(dataset)
+    elif not isinstance(dataset, list):
+        dataset = [dataset]
         
     assert len(dataset) == len(splits), "datasets length must equal splits length"
     assert len(dataset) == len(weights), "datasets length must equal weights length"
@@ -149,8 +153,10 @@ def build_image_train_loader(
         batch_size: Batch-size for each GPU.
     """
     # TODO: add input type
-   
-    dataset = [dataset]
+    if isinstance(dataset, omegaconf.listconfig.ListConfig):
+        dataset = list(dataset)
+    elif not isinstance(dataset, list):
+        dataset = [dataset]
 
     if len(dataset) > 1:
         dataset = dataset_mixer(dataset)

--- a/libai/trainer/default.py
+++ b/libai/trainer/default.py
@@ -471,5 +471,7 @@ class DefaultTrainer(TrainerBase):
         ), f"dataloader.test must be list but got type of {type(cfg.dataloader.test)}"
         for i in range(len(cfg.dataloader.test)):
             cfg.dataloader.test[i].test_batch_size = cfg.train.test_micro_batch_size
-        test_loader = instantiate(cfg.dataloader.test)  # list[dataloader1, dataloader2, ...]
+        test_loader = instantiate(
+            cfg.dataloader.test
+        )  # list[dataloader1, dataloader2, ...]
         return test_loader

--- a/libai/trainer/default.py
+++ b/libai/trainer/default.py
@@ -15,6 +15,7 @@
 
 import logging
 import os
+import omegaconf
 
 import oneflow as flow
 from libai.config import LazyConfig, try_get_key
@@ -47,49 +48,49 @@ def _highlight(code, filename):
 
 
 def _check_batch_size(cfg):
-    micro_batch_size = try_get_key(cfg, "train.micro_batch_size", default=None)
+    train_micro_batch_size = try_get_key(cfg, "train.train_micro_batch_size", default=None)
     global_batch_size = try_get_key(cfg, "train.global_batch_size", default=None)
     num_accumulation_steps = try_get_key(
         cfg, "train.num_accumulation_steps", default=None
     )
 
-    if micro_batch_size is not None and global_batch_size is not None:
+    if train_micro_batch_size is not None and global_batch_size is not None:
         if num_accumulation_steps is None:
             if (
-                global_batch_size % (micro_batch_size * dist.get_data_parallel_size())
+                global_batch_size % (train_micro_batch_size * dist.get_data_parallel_size())
                 != 0
             ):
                 raise ValueError(
                     f"global_batch_size {global_batch_size} must be divisible by "
-                    f"micro_batch_size * data_parallel_size ({micro_batch_size} * {dist.get_data_parallel_size()})"
+                    f"train_micro_batch_size * data_parallel_size ({train_micro_batch_size} * {dist.get_data_parallel_size()})"
                 )
 
             cfg.train.num_accumulation_steps = global_batch_size // (
-                micro_batch_size * dist.get_data_parallel_size()
+                train_micro_batch_size * dist.get_data_parallel_size()
             )
 
         else:
             if (
                 global_batch_size
-                != micro_batch_size
+                != train_micro_batch_size
                 * dist.get_data_parallel_size()
                 * num_accumulation_steps
             ):
                 raise ValueError(
                     f"global_batch_size {global_batch_size} must equal"
-                    " micro_batch_size * data_parallel_size * num_accumulation_steps"
-                    f" ({micro_batch_size} * {dist.get_data_parallel_size()} * {num_accumulation_steps})"
+                    " train_micro_batch_size * data_parallel_size * num_accumulation_steps"
+                    f" ({train_micro_batch_size} * {dist.get_data_parallel_size()} * {num_accumulation_steps})"
                 )
-    elif micro_batch_size is not None and global_batch_size is None:
+    elif train_micro_batch_size is not None and global_batch_size is None:
         if num_accumulation_steps is None:
             cfg.train.num_accumulation_steps = 1
 
         cfg.train.global_batch_size = (
-            micro_batch_size
+            train_micro_batch_size
             * dist.get_data_parallel_size()
             * cfg.train.num_accumulation_steps
         )
-    elif micro_batch_size is None and global_batch_size is not None:
+    elif train_micro_batch_size is None and global_batch_size is not None:
         if num_accumulation_steps is None:
             cfg.train.num_accumulation_steps = 1
 
@@ -104,11 +105,11 @@ def _check_batch_size(cfg):
                 f"({dist.get_data_parallel_size()} * {cfg.train.num_accumulation_steps})"
             )
 
-        cfg.train.micro_batch_size = global_batch_size // (
+        cfg.train.train_micro_batch_size = global_batch_size // (
             dist.get_data_parallel_size() * cfg.train.num_accumulation_steps
         )
     else:
-        raise ValueError("micro_batch_size and global_batch_size must be set either")
+        raise ValueError("train_micro_batch_size and global_batch_size must be set either")
 
 
 def default_setup(cfg, args):
@@ -447,6 +448,9 @@ class DefaultTrainer(TrainerBase):
         ), "cfg must contain `dataloader.train` namespace"
         logger = logging.getLogger(__name__)
         logger.info("Prepare training, validating, testing set")
+        assert isinstance(cfg.dataloader.train, omegaconf.listconfig.ListConfig), "dataloader.train must be list"
+        cfg.dataloader.train.train_batch_size = cfg.train.train_micro_batch_size
+        cfg.dataloader.train.test_batch_size = cfg.train.test_micro_batch_size
         train_loader, valid_loader, test_loader = instantiate(cfg.dataloader.train)
         return train_loader, valid_loader, test_loader
 
@@ -458,5 +462,8 @@ class DefaultTrainer(TrainerBase):
         ), "cfg must contain `dataloader.test` namespace"
         logger = logging.getLogger(__name__)
         logger.info("Prepare testing set")
+        assert isinstance(cfg.dataloader.test, omegaconf.listconfig.ListConfig), "dataloader.test must be list"
+        for i in range(len(cfg.dataloader.test)):
+            cfg.dataloader.test[i].test_batch_size = cfg.train.test_micro_batch_size
         test_loader = instantiate(cfg.dataloader.test)  # list[dataloader1, dataloader2]
         return test_loader

--- a/libai/trainer/default.py
+++ b/libai/trainer/default.py
@@ -448,7 +448,6 @@ class DefaultTrainer(TrainerBase):
         ), "cfg must contain `dataloader.train` namespace"
         logger = logging.getLogger(__name__)
         logger.info("Prepare training, validating, testing set")
-        assert isinstance(cfg.dataloader.train, omegaconf.listconfig.ListConfig), "dataloader.train must be list"
         cfg.dataloader.train.train_batch_size = cfg.train.train_micro_batch_size
         cfg.dataloader.train.test_batch_size = cfg.train.test_micro_batch_size
         train_loader, valid_loader, test_loader = instantiate(cfg.dataloader.train)

--- a/libai/trainer/default.py
+++ b/libai/trainer/default.py
@@ -468,8 +468,8 @@ class DefaultTrainer(TrainerBase):
         logger.info("Prepare testing set")
         assert isinstance(
             cfg.dataloader.test, omegaconf.listconfig.ListConfig
-        ), "dataloader.test must be list"
+        ), f"dataloader.test must be list but got type of {type(cfg.dataloader.test)}"
         for i in range(len(cfg.dataloader.test)):
             cfg.dataloader.test[i].test_batch_size = cfg.train.test_micro_batch_size
-        test_loader = instantiate(cfg.dataloader.test)  # list[dataloader1, dataloader2]
+        test_loader = instantiate(cfg.dataloader.test)  # list[dataloader1, dataloader2, ...]
         return test_loader

--- a/libai/trainer/default.py
+++ b/libai/trainer/default.py
@@ -48,7 +48,9 @@ def _highlight(code, filename):
 
 
 def _check_batch_size(cfg):
-    train_micro_batch_size = try_get_key(cfg, "train.train_micro_batch_size", default=None)
+    train_micro_batch_size = try_get_key(
+        cfg, "train.train_micro_batch_size", default=None
+    )
     global_batch_size = try_get_key(cfg, "train.global_batch_size", default=None)
     num_accumulation_steps = try_get_key(
         cfg, "train.num_accumulation_steps", default=None
@@ -57,7 +59,8 @@ def _check_batch_size(cfg):
     if train_micro_batch_size is not None and global_batch_size is not None:
         if num_accumulation_steps is None:
             if (
-                global_batch_size % (train_micro_batch_size * dist.get_data_parallel_size())
+                global_batch_size
+                % (train_micro_batch_size * dist.get_data_parallel_size())
                 != 0
             ):
                 raise ValueError(
@@ -109,7 +112,9 @@ def _check_batch_size(cfg):
             dist.get_data_parallel_size() * cfg.train.num_accumulation_steps
         )
     else:
-        raise ValueError("train_micro_batch_size and global_batch_size must be set either")
+        raise ValueError(
+            "train_micro_batch_size and global_batch_size must be set either"
+        )
 
 
 def default_setup(cfg, args):
@@ -461,7 +466,9 @@ class DefaultTrainer(TrainerBase):
         ), "cfg must contain `dataloader.test` namespace"
         logger = logging.getLogger(__name__)
         logger.info("Prepare testing set")
-        assert isinstance(cfg.dataloader.test, omegaconf.listconfig.ListConfig), "dataloader.test must be list"
+        assert isinstance(
+            cfg.dataloader.test, omegaconf.listconfig.ListConfig
+        ), "dataloader.test must be list"
         for i in range(len(cfg.dataloader.test)):
             cfg.dataloader.test[i].test_batch_size = cfg.train.test_micro_batch_size
         test_loader = instantiate(cfg.dataloader.test)  # list[dataloader1, dataloader2]

--- a/tests/data/datasets/demo_dataset.py
+++ b/tests/data/datasets/demo_dataset.py
@@ -36,9 +36,9 @@ class DemoNlpDataset(flow.utils.data.Dataset):
     def __getitem__(self, idx):
         sample = Instance(
             input=DistTensorData(
-                flow.ones((32, 128), dtype=flow.long), placement_idx=0
+                flow.ones((128, 256), dtype=flow.long), placement_idx=0
             ),
-            label=DistTensorData(flow.ones((32,), dtype=flow.long), placement_idx=-1),
+            label=DistTensorData(flow.ones((128,), dtype=flow.long), placement_idx=-1),
         )
         return sample
 

--- a/tests/data/test_nlp_loader.py
+++ b/tests/data/test_nlp_loader.py
@@ -121,25 +121,6 @@ class DemoTrainer(DefaultTrainer):
     def build_graph(cls, cfg, model, optimizer=None, lr_scheduler=None, is_train=True):
         return build_graph(cfg, model, optimizer, lr_scheduler)
 
-    # @classmethod
-    # def get_batch(cls, data):
-    #     return [
-    #         flow.randn(
-    #             32,
-    #             512,
-    #             sbp=flow.sbp.split(0),
-    #             placement=flow.placement("cuda", {0: [0]}),
-    #         )
-    #     ]
-
-    # @classmethod
-    # def build_train_loader(cls, cfg):
-    #     return range(1000), range(10), range(10)
-
-    # @classmethod
-    # def build_test_loader(cls, cfg):
-    #     return [range(10)]
-
 
 def main(args):
     cfg = setup(args)
@@ -150,7 +131,7 @@ def main(args):
     for sample in trainer.train_loader:
         assert isinstance(sample, Instance)
         print(
-            f"train sample shape f{sample.input.tensor.shape} f{sample.label.tensor.shape}"
+            f"train sample shape {sample.input.tensor.shape} {sample.label.tensor.shape}"
         )
         break
 
@@ -159,7 +140,7 @@ def main(args):
         for sample in loader:
             assert isinstance(sample, Instance)
             print(
-                f"train sample shape f{sample.input.tensor.shape} f{sample.label.tensor.shape}"
+                f"train sample shape {sample.input.tensor.shape} {sample.label.tensor.shape}"
             )
             break
 

--- a/tests/data/test_nlp_loader.py
+++ b/tests/data/test_nlp_loader.py
@@ -12,25 +12,154 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+import oneflow as flow
 import sys
+from omegaconf import OmegaConf
 
 sys.path.append(".")
-
-from libai.config.instantiate import instantiate
-from libai.config import LazyConfig
+from libai.trainer import DefaultTrainer, default_setup
+from libai.config import default_argument_parser, LazyCall
+from libai.optim import get_default_optimizer_params
+from libai.scheduler import WarmupCosineLR
+from libai.data.build import build_nlp_test_loader, build_nlp_train_val_test_loader
+from tests.data.datasets.demo_dataset import DemoNlpDataset
 from libai.data.structures import Instance
 
-cfg = LazyConfig.load("./configs/common/data/nlp_data.py")
+from tests.layers.test_trainer_model import build_model, build_graph
 
-train_loader, val_loader, test_loader = instantiate(cfg.dataloader.train)
-print(len(train_loader), len(val_loader), len(test_loader))
-for sample in test_loader:
-    assert isinstance(sample, Instance)
-    break
 
-test_loader = instantiate(cfg.dataloader.test)
-for loader in test_loader:
-    print(f"test loader: {len(loader)}")
-    for sample in loader:
+def setup(args):
+    """
+    Create configs and perform basic setups.
+    """
+
+    cfg = OmegaConf.create()
+
+    cfg.train = dict(
+        output_dir="./demo_output",
+        train_micro_batch_size=32,
+        test_micro_batch_size=16,
+        dist=dict(
+            data_parallel_size=1,
+            tensor_parallel_size=1,
+            pipeline_parallel_size=1,
+            pipeline_num_layers=4,
+        ),
+        start_iter=0,
+        train_iter=20,
+        lr_warmup_fraction=0.01,
+        lr_decay_iter=6000,
+        log_period=1,
+        checkpointer=dict(period=100),
+        nccl_fusion_threshold_mb=16,
+        nccl_fusion_max_ops=24,
+    )
+
+    cfg.optim = LazyCall(flow.optim.AdamW)(
+        parameters=LazyCall(get_default_optimizer_params)(
+            # parameters.model is meant to be set to the model object, before instantiating the optimizer.
+            clip_grad_max_norm=1.0,
+            clip_grad_norm_type=2.0,
+            weight_decay_norm=0.0,
+            weight_decay_bias=0.0,
+        ),
+        lr=1e-4,
+        weight_decay=0.01,
+        betas=(0.9, 0.999),
+        do_bias_correction=True,
+    )
+
+    cfg.scheduler = LazyCall(WarmupCosineLR)(
+        max_iters=2000,
+        alpha=0.001,
+        warmup_factor=0.001,
+        warmup_iters=1000,
+        warmup_method="linear",
+    )
+    
+    cfg.dataloader = OmegaConf.create()
+    
+    cfg.dataloader.train = LazyCall(build_nlp_train_val_test_loader)(
+        dataset=[
+            LazyCall(DemoNlpDataset)(data_root="train1",),
+            LazyCall(DemoNlpDataset)(data_root="train2",),
+        ],
+        splits=[[949.0, 50.0, 1.0], [900.0, 99.0, 1.0]],
+        weights=[0.5, 0.5],
+        num_workers=4,
+    )
+    
+    cfg.dataloader.test = [
+        LazyCall(build_nlp_test_loader)(
+            dataset=LazyCall(DemoNlpDataset)(data_root="test1",)
+        ),
+        LazyCall(build_nlp_test_loader)(
+            dataset=LazyCall(DemoNlpDataset)(data_root="test2",)
+        )
+    ]
+
+    cfg.graph = dict(enabled=True,)
+
+    default_setup(cfg, args)
+    return cfg
+
+
+class DemoTrainer(DefaultTrainer):
+    @classmethod
+    def build_model(cls, cfg):
+        """
+        Returns:
+            flow.nn.Module:
+        It now calls :func:`libai.layers.build_model`.
+        Overwrite it if you'd like a different model.
+        """
+        model = build_model(cfg)
+        return model
+
+    @classmethod
+    def build_graph(cls, cfg, model, optimizer=None, lr_scheduler=None, is_train=True):
+        return build_graph(cfg, model, optimizer, lr_scheduler)
+
+    # @classmethod
+    # def get_batch(cls, data):
+    #     return [
+    #         flow.randn(
+    #             32,
+    #             512,
+    #             sbp=flow.sbp.split(0),
+    #             placement=flow.placement("cuda", {0: [0]}),
+    #         )
+    #     ]
+
+    # @classmethod
+    # def build_train_loader(cls, cfg):
+    #     return range(1000), range(10), range(10)
+
+    # @classmethod
+    # def build_test_loader(cls, cfg):
+    #     return [range(10)]
+
+
+def main(args):
+    cfg = setup(args)
+
+    trainer = DemoTrainer(cfg)
+
+    print(len(trainer.train_loader), len(trainer.test_loader))
+    for sample in trainer.train_loader:
         assert isinstance(sample, Instance)
+        print(f"train sample shape f{sample.input.tensor.shape} f{sample.label.tensor.shape}")
         break
+
+    for loader in trainer.test_loader:
+        print(f"test loader: {len(loader)}")
+        for sample in loader:
+            assert isinstance(sample, Instance)
+            print(f"train sample shape f{sample.input.tensor.shape} f{sample.label.tensor.shape}")
+            break
+
+
+if __name__ == "__main__":
+    args = default_argument_parser().parse_args()
+    main(args)

--- a/tests/data/test_nlp_loader.py
+++ b/tests/data/test_nlp_loader.py
@@ -77,9 +77,9 @@ def setup(args):
         warmup_iters=1000,
         warmup_method="linear",
     )
-    
+
     cfg.dataloader = OmegaConf.create()
-    
+
     cfg.dataloader.train = LazyCall(build_nlp_train_val_test_loader)(
         dataset=[
             LazyCall(DemoNlpDataset)(data_root="train1",),
@@ -89,14 +89,14 @@ def setup(args):
         weights=[0.5, 0.5],
         num_workers=4,
     )
-    
+
     cfg.dataloader.test = [
         LazyCall(build_nlp_test_loader)(
             dataset=LazyCall(DemoNlpDataset)(data_root="test1",)
         ),
         LazyCall(build_nlp_test_loader)(
             dataset=LazyCall(DemoNlpDataset)(data_root="test2",)
-        )
+        ),
     ]
 
     cfg.graph = dict(enabled=True,)
@@ -149,14 +149,18 @@ def main(args):
     print(len(trainer.train_loader), len(trainer.test_loader))
     for sample in trainer.train_loader:
         assert isinstance(sample, Instance)
-        print(f"train sample shape f{sample.input.tensor.shape} f{sample.label.tensor.shape}")
+        print(
+            f"train sample shape f{sample.input.tensor.shape} f{sample.label.tensor.shape}"
+        )
         break
 
     for loader in trainer.test_loader:
         print(f"test loader: {len(loader)}")
         for sample in loader:
             assert isinstance(sample, Instance)
-            print(f"train sample shape f{sample.input.tensor.shape} f{sample.label.tensor.shape}")
+            print(
+                f"train sample shape f{sample.input.tensor.shape} f{sample.label.tensor.shape}"
+            )
             break
 
 


### PR DESCRIPTION
这个pr所做的:
- [x] 在config中统一train和test的`batch_size`
- [x] 修改单测脚本, 跑通并达到期望值

由于graph在构图时, `batch_size`已经固定了, 所以在train和test的时候, 我们只能统一一个`batch_size`
所以在config下面我把batch_size全部统一放到了`cfg.train`下面
```python
train = dict(
    output_dir="./demo_output/test_config",

    train_micro_batch_size=32,
    test_micro_batch_size=32,
    ...,
)
```
在我构建evaluator时, 进行`pad_batch`的时候, 更方便去一个`cfg.train`里面统一的拿, 
而不是去每个dataset的cfg下面用for循环去拿, 避免用户自己定义dataset的时候, 忽略这个点造成不必要的麻烦.