### PR TITLE
add mixup

### DIFF
--- a/configs/bert_large_pretrain.py
+++ b/configs/bert_large_pretrain.py
@@ -14,7 +14,7 @@ model.cfg.hidden_layers = 8
 train.train_micro_batch_size = 16
 
 train.amp.enabled = False
-train.recompute_grad.enabled = False
+train.recompute_grad.enabled = True
 
 # LazyCall
 graph = dict(

--- a/configs/common/data/cifar.py
+++ b/configs/common/data/cifar.py
@@ -1,5 +1,6 @@
 from omegaconf import OmegaConf
 from flowvision import transforms
+from flowvision.data.mixup import Mixup
 from flowvision.transforms import InterpolationMode
 from flowvision.transforms.functional import str_to_interp_mode
 
@@ -47,8 +48,21 @@ test_aug = LazyCall(transforms.Compose)(
 dataloader = OmegaConf.create()
 dataloader.train = LazyCall(build_image_train_loader)(
     dataset=[
-        LazyCall(CIFAR100Dataset)(root="./", train=True, download=True, transform=train_aug),
+        LazyCall(CIFAR100Dataset)(
+            root="./",
+            train=True,
+            download=True,
+            transform=train_aug,
+        ),
     ],
+    mixup_func=LazyCall(Mixup)(
+        mixup_alpha=0.8,
+        cutmix_alpha=1.0,
+        prob=1.0,
+        switch_prob=0.5,
+        mode="batch",
+        num_classes=100,
+    ),
 )
 
 dataloader.test = [

--- a/configs/common/models/vit.py
+++ b/configs/common/models/vit.py
@@ -2,7 +2,8 @@ from libai.config import LazyCall
 
 from libai.models import VisionTransformer
 
-cfg = dict(
+
+vit_model = LazyCall(VisionTransformer)(
     img_size=224,
     patch_size=16,
     in_chans=3,
@@ -16,5 +17,3 @@ cfg = dict(
     drop_path_rate=0.1,
     num_classes=1000,
 )
-
-vit_model = LazyCall(VisionTransformer)(cfg=cfg)

--- a/configs/vit_imagenet.py
+++ b/configs/vit_imagenet.py
@@ -4,8 +4,12 @@ from .common.train import train
 from .common.optim import optim
 from .common.data.cifar import dataloader
 
-
 from libai.models import VisionTransformerGraph
+from flowvision.loss.cross_entropy import SoftTargetCrossEntropy
+
+model.num_classes = 100
+model.loss_func = LazyCall(SoftTargetCrossEntropy)()
+
 
 # Refine optimizer cfg for vit model
 optim.lr = 5e-4

--- a/libai/data/build.py
+++ b/libai/data/build.py
@@ -155,6 +155,7 @@ def build_image_train_loader(
     seed=42,
     collate_fn=None,
     dataset_mixer=ConcatDataset,
+    mixup_func=None,
     **kwargs
 ):
     """
@@ -190,6 +191,8 @@ def build_image_train_loader(
         collate_fn=trivial_batch_collator if collate_fn is None else collate_fn,
         **kwargs,
     )
+    # Bind up mixup_func to dataloader, and this will be used in Trainer.step
+    dataloader.mixup_func = mixup_func
 
     return dataloader, None, None
 

--- a/libai/models/vision_transformer.py
+++ b/libai/models/vision_transformer.py
@@ -21,6 +21,7 @@ import oneflow as flow
 import oneflow.nn as nn
 from flowvision.layers.blocks import Mlp, PatchEmbed
 from flowvision.layers.weight_init import lecun_normal_, trunc_normal_
+from flowvision.loss.cross_entropy import SoftTargetCrossEntropy
 from flowvision.models.helpers import named_apply
 
 from libai.config.config import configurable
@@ -244,7 +245,7 @@ class VisionTransformer(nn.Module):
             )
 
         # Loss func
-        self.loss_func = nn.CrossEntropyLoss()
+        self.loss_func = SoftTargetCrossEntropy()
 
         self.init_weights(weight_init)
 

--- a/libai/models/vision_transformer.py
+++ b/libai/models/vision_transformer.py
@@ -21,7 +21,6 @@ import oneflow as flow
 import oneflow.nn as nn
 from flowvision.layers.blocks import Mlp, PatchEmbed
 from flowvision.layers.weight_init import lecun_normal_, trunc_normal_
-from flowvision.loss.cross_entropy import SoftTargetCrossEntropy
 from flowvision.models.helpers import named_apply
 
 from libai.config.config import configurable
@@ -157,6 +156,7 @@ class VisionTransformer(nn.Module):
         norm_layer=None,
         act_layer=None,
         weight_init="",
+        loss_func=None,
     ):
         """
         Args:
@@ -245,7 +245,7 @@ class VisionTransformer(nn.Module):
             )
 
         # Loss func
-        self.loss_func = SoftTargetCrossEntropy()
+        self.loss_func = nn.CrossEntropyLoss() if loss_func is None else loss_func
 
         self.init_weights(weight_init)
 

--- a/libai/trainer/default.py
+++ b/libai/trainer/default.py
@@ -17,6 +17,7 @@ import logging
 import math
 import os
 from collections import OrderedDict
+from typing import Callable, Optional
 
 import omegaconf
 import oneflow as flow
@@ -360,7 +361,7 @@ class DefaultTrainer(TrainerBase):
         self._trainer.run_step(self.get_batch)
 
     @classmethod
-    def get_batch(cls, data: Instance):
+    def get_batch(cls, data: Instance, mixup_func: Optional[Callable] = None):
         """
         Convert batched local tensor to distributed tensor for model step running.
 
@@ -369,6 +370,11 @@ class DefaultTrainer(TrainerBase):
         """
         if isinstance(data, flow.utils.data._utils.worker.ExceptionWrapper):
             data.reraise()
+
+        if mixup_func is not None:
+            images, targets = mixup_func(data.get("images").tensor, data.get("targets").tensor)
+            data.get("images").tensor = images
+            data.get("targets").tensor = targets
 
         ret_dict = {}
         ret_list = []

--- a/libai/trainer/trainer.py
+++ b/libai/trainer/trainer.py
@@ -232,7 +232,7 @@ class EagerTrainer(TrainerBase):
     or write your own training loop.
     """
 
-    def __init__(self, model, data_loader_iter, optimizer):
+    def __init__(self, model, data_loader, optimizer):
         """
         Args:
             model: a flow.nn.Module. Takes a data from data_loader and returns a
@@ -250,7 +250,8 @@ class EagerTrainer(TrainerBase):
         model.train()
 
         self.model = model
-        self._data_loader_iter = iter(data_loader_iter)
+        self.data_loader = data_loader
+        self._data_loader_iter = iter(data_loader)
         self.optimizer = optimizer
 
     def run_step(self, get_batch: Callable):
@@ -262,35 +263,28 @@ class EagerTrainer(TrainerBase):
 
         # If you want to do something with the data, you can wrap the dataloader.
         data = next(self._data_loader_iter)
-        data = get_batch(data)
+        data = get_batch(data, getattr(self.data_loader, "mixup_func", None))
         data_time = time.perf_counter() - start
 
         # If you want to do something with the losses, you can wrap the model.
-
         losses = self.model(*data)
         loss_dict = {"total_loss": losses}
-
-        # If you need to accumulate gradients or do something similar, you can
-        # wrap the optimizer with your custom `zero_grad()` method.
 
         self.optimizer.zero_grad()
         losses.backward()
 
         self.write_metrics(loss_dict, data_time)
 
-        # If you need gradient clipping/scaling or other processing, you can
-        # wrap the optimizer with your custom `step()` method. But it is
-        # suboptimal as explained in https://arxiv.org/abs/2006.15704 Sec 3.2.4
-
         self.optimizer.step()
 
 
 class GraphTrainer(TrainerBase):
-    def __init__(self, graph, data_loader_iter):
+    def __init__(self, graph, data_loader):
         super().__init__()
 
         graph.model.train()
-        self._data_loader_iter = iter(data_loader_iter)
+        self.data_loader = data_loader
+        self._data_loader_iter = iter(data_loader)
         self.graph = graph
 
     def run_step(self, get_batch: Callable):
@@ -302,11 +296,10 @@ class GraphTrainer(TrainerBase):
 
         # If you want to do something with the data, you can wrap the dataloader.
         data = next(self._data_loader_iter)
-        data = get_batch(data)
+        data = get_batch(data, getattr(self.data_loader, "mixup_func", None))
         data_time = time.perf_counter() - start
 
         # If you want to do something with the losses, you can wrap the model.
-
         losses = self.graph(*data)
         loss_dict = {"total_loss": losses}
 


### PR DESCRIPTION
这个 PR 增加 mixup/cutmix 数据增强方法，区别于一般的数据增强方法，只需要作用在单个 sample 上，mixup 需要作用在一个 batch 的数据集上。

本来考虑将 mixup_func 和每个 dataset 绑定，不过考虑到多个 dataset 输入的时候，相同的信息需要写多次，而且 concatDataset 会覆盖掉这个信息，最终决定将 mixup_func 和 dataloader 绑定，在 get_batch 中进行 mixup_func 的处理。