### PR TITLE
Refine config

### DIFF
--- a/configs/common/data/imagenet.py
+++ b/configs/common/data/imagenet.py
@@ -69,6 +69,7 @@ dataloader.train = LazyCall(build_image_train_loader)(
     dataset=[
         LazyCall(ImageNetDataset)(root="./dataset", train=True, transform=train_aug),
     ],
+    mixup_func=None,
 )
 
 

--- a/configs/common/models/vit/vit_base_patch16_224.py
+++ b/configs/common/models/vit/vit_base_patch16_224.py
@@ -1,0 +1,5 @@
+from .vit_tiny_patch16_224 import model
+
+model.patch_size = 16
+model.embed_dim = 768
+model.num_heads = 12

--- a/configs/common/models/vit/vit_base_patch32_224.py
+++ b/configs/common/models/vit/vit_base_patch32_224.py
@@ -1,0 +1,5 @@
+from .vit_tiny_patch16_224 import model
+
+model.patch_size = 32
+model.embed_dim = 768
+model.num_heads = 12

--- a/configs/common/models/vit/vit_giant_patch14_224.py
+++ b/configs/common/models/vit/vit_giant_patch14_224.py
@@ -1,0 +1,7 @@
+from .vit_tiny_patch16_224 import model
+
+model.patch_size = 14
+model.embed_dim = 1408
+model.mlp_ratio = 48 / 11
+model.depth = 40
+model.num_heads = 16

--- a/configs/common/models/vit/vit_gigantic_patch14_224.py
+++ b/configs/common/models/vit/vit_gigantic_patch14_224.py
@@ -1,0 +1,7 @@
+from .vit_tiny_patch16_224 import model
+
+model.patch_size = 14
+model.embed_dim = 1664
+model.mlp_ratio = 64 / 13
+model.depth = 48
+model.num_heads = 16

--- a/configs/common/models/vit/vit_huge_patch14_224.py
+++ b/configs/common/models/vit/vit_huge_patch14_224.py
@@ -1,0 +1,6 @@
+from .vit_tiny_patch16_224 import model
+
+model.patch_size = 16
+model.embed_dim = 1280
+model.depth = 32
+model.num_heads = 16

--- a/configs/common/models/vit/vit_large_patch16_224.py
+++ b/configs/common/models/vit/vit_large_patch16_224.py
@@ -1,0 +1,6 @@
+from .vit_tiny_patch16_224 import model
+
+model.patch_size = 16
+model.embed_dim = 1024
+model.depth = 24
+model.num_heads = 16

--- a/configs/common/models/vit/vit_large_patch32_224.py
+++ b/configs/common/models/vit/vit_large_patch32_224.py
@@ -1,0 +1,6 @@
+from .vit_tiny_patch16_224 import model
+
+model.patch_size = 32
+model.embed_dim = 1024
+model.depth = 24
+model.num_heads = 16

--- a/configs/common/models/vit/vit_small_patch16_224.py
+++ b/configs/common/models/vit/vit_small_patch16_224.py
@@ -1,0 +1,5 @@
+from .vit_tiny_patch16_224 import model
+
+model.patch_size = 16
+model.embed_dim = 384
+model.num_heads = 6

--- a/configs/common/models/vit/vit_small_patch32_224.py
+++ b/configs/common/models/vit/vit_small_patch32_224.py
@@ -1,0 +1,5 @@
+from .vit_tiny_patch16_224 import model
+
+model.patch_size = 32
+model.embed_dim = 384
+model.num_heads = 6

--- a/configs/common/models/vit/vit_tiny_patch16_224.py
+++ b/configs/common/models/vit/vit_tiny_patch16_224.py
@@ -3,17 +3,17 @@ from libai.config import LazyCall
 from libai.models import VisionTransformer
 
 
-vit_model = LazyCall(VisionTransformer)(
+model = LazyCall(VisionTransformer)(
     img_size=224,
     patch_size=16,
     in_chans=3,
-    embed_dim=384,
+    embed_dim=192,
     mlp_ratio=4.0,
     depth=12,
-    num_heads=6,
+    num_heads=3,
     qkv_bias=True,
-    drop_rate=0.1,
-    attn_drop_rate=0.1,
-    drop_path_rate=0.1,
+    drop_rate=0.0,
+    attn_drop_rate=0.0,
+    drop_path_rate=0.0,
     num_classes=1000,
 )

--- a/configs/common/train.py
+++ b/configs/common/train.py
@@ -3,7 +3,7 @@ from libai.scheduler import WarmupCosineLR
 
 # fmt: off
 train = dict(
-    output_dir="./demo_output/test_config",
+    output_dir="./output",
 
     # Batch size and gradient accumulation
     train_micro_batch_size=32,
@@ -14,8 +14,6 @@ train = dict(
     train_iter=10000,
     train_epoch=0,  # default train epoch is set to 0
     warmup_ratio=0,  # default warmup ratio is set to 0
-    lr_decay_iter=None,
-    eval_iter=10000,
 
     # Performance related
     amp=dict(enabled=False),  # options for Automatic Mixed Precision

--- a/configs/vit_imagenet.py
+++ b/configs/vit_imagenet.py
@@ -12,6 +12,9 @@ from flowvision.loss.cross_entropy import SoftTargetCrossEntropy
 dataloader.train.dataset[0].root = "/path/to/imagenet"
 dataloader.test[0].dataset.root = "/path/to/imagenet"
 
+dataloader.train.dataset[0].root = "/dataset/imagenet/extract/"
+dataloader.test[0].dataset.root = "/dataset/imagenet/extract/"
+
 # Add MixupFunc
 dataloader.train.mixup_func = LazyCall(Mixup)(
     mixup_alpha=0.8,
@@ -32,7 +35,7 @@ optim.eps = 1e-8
 optim.weight_decay = 0.05
 
 # Refine train cfg for vit model
-train.train_micro_batch_size = 128
+train.train_micro_batch_size = 32
 train.test_micro_batch_size = 128
 train.train_epoch = 300
 train.warmup_ratio = 20 / 300

--- a/configs/vit_imagenet.py
+++ b/configs/vit_imagenet.py
@@ -1,15 +1,30 @@
 from libai.config import LazyCall
-from .common.models.vit import vit_model as model
+from .common.models.vit.vit_tiny_patch16_224 import model
+from .common.models.graph import graph
 from .common.train import train
 from .common.optim import optim
-from .common.data.cifar import dataloader
+from .common.data.imagenet import dataloader
 
-from libai.models import VisionTransformerGraph
+from flowvision.data import Mixup
 from flowvision.loss.cross_entropy import SoftTargetCrossEntropy
 
-model.num_classes = 100
-model.loss_func = LazyCall(SoftTargetCrossEntropy)()
+# Refine data path to imagenet
+dataloader.train.dataset[0].root = "/path/to/imagenet"
+dataloader.test[0].dataset.root = "/path/to/imagenet"
 
+# Add MixupFunc
+dataloader.train.mixup_func = LazyCall(Mixup)(
+    mixup_alpha=0.8,
+    cutmix_alpha=1.0,
+    prob=1.0,
+    switch_prob=0.5,
+    mode="batch",
+    num_classes=1000,
+)
+
+# Refine model cfg for vit training on imagenet
+model.num_classes = 1000
+model.loss_func = LazyCall(SoftTargetCrossEntropy)()
 
 # Refine optimizer cfg for vit model
 optim.lr = 5e-4
@@ -31,16 +46,3 @@ train.scheduler.warmup_method = "linear"
 
 # Set fp16 ON
 train.amp.enabled = True
-
-# fmt: off
-graph = dict(
-    # options for graph or eager mode
-    enabled=True,
-    train_graph=LazyCall(VisionTransformerGraph)(
-        is_train=True,
-    ),
-    eval_graph=LazyCall(VisionTransformerGraph)(
-        is_train=False,),
-    debug=-1,
-)
-# fmt: on

--- a/configs/vit_imagenet.py
+++ b/configs/vit_imagenet.py
@@ -12,9 +12,6 @@ from flowvision.loss.cross_entropy import SoftTargetCrossEntropy
 dataloader.train.dataset[0].root = "/path/to/imagenet"
 dataloader.test[0].dataset.root = "/path/to/imagenet"
 
-dataloader.train.dataset[0].root = "/dataset/imagenet/extract/"
-dataloader.test[0].dataset.root = "/dataset/imagenet/extract/"
-
 # Add MixupFunc
 dataloader.train.mixup_func = LazyCall(Mixup)(
     mixup_alpha=0.8,

--- a/docs/source/libai.layers.rst
+++ b/docs/source/libai.layers.rst
@@ -4,4 +4,14 @@ libai.layers
 .. currentmodule:: libai.layers
 .. automodule:: libai.layers
     :members: 
+        Embedding,
+        VocabEmbedding,
+        SinePositionalEmbedding,
+        build_activation,
+        Linear,
+        Linear1D,
+        MLP,
         LayerNorm,
+        TransformerLayer,
+        ParallelCrossEntropyLoss,
+        LMLogits

--- a/docs/source/libai.scheduler.rst
+++ b/docs/source/libai.scheduler.rst
@@ -1,2 +1,11 @@
 libai.scheduler
 ##############################
+
+.. currentmodule:: libai.scheduler
+.. automodule:: libai.scheduler
+    :members: 
+        WarmupCosineAnnealingLR,
+        WarmupCosineLR,
+        WarmupExponentialLR,
+        WarmupMultiStepLR,
+        WarmupPolynomialLR

--- a/docs/source/libai.tokenizer.rst
+++ b/docs/source/libai.tokenizer.rst
@@ -1,2 +1,9 @@
 libai.tokenizer
 ##############################
+
+.. currentmodule:: libai.tokenizer
+.. automodule:: libai.tokenizer
+    :members:
+        BertTokenizer,
+        GPT2Tokenizer,
+        T5Tokenizer

--- a/libai/data/datasets/cifar.py
+++ b/libai/data/datasets/cifar.py
@@ -41,7 +41,7 @@ class CIFAR10Dataset(datasets.CIFAR10):
         print(img)
         data_sample = Instance(
             images=DistTensorData(img, placement_idx=0),
-            targets=DistTensorData(flow.tensor(target, dtype=flow.long), placement_idx=-1),
+            label=DistTensorData(flow.tensor(target, dtype=flow.long), placement_idx=-1),
         )
         return data_sample
 

--- a/libai/data/datasets/imagenet.py
+++ b/libai/data/datasets/imagenet.py
@@ -36,6 +36,6 @@ class ImageNetDataset(datasets.ImageFolder):
         sample, target = super().__getitem__(index)
         data_sample = Instance(
             images=DistTensorData(sample, placement_idx=0),
-            targets=DistTensorData(flow.tensor(target, dtype=flow.long), placement_idx=-1),
+            label=DistTensorData(flow.tensor(target, dtype=flow.long), placement_idx=-1),
         )
         return data_sample

--- a/libai/data/datasets/mnist.py
+++ b/libai/data/datasets/mnist.py
@@ -40,6 +40,6 @@ class MNISTDataset(datasets.MNIST):
         img, target = super().__getitem__(index)
         data_sample = Instance(
             images=DistTensorData(img, placement_idx=0),
-            targets=DistTensorData(flow.tensor(target, dtype=flow.long), placement_idx=-1),
+            label=DistTensorData(flow.tensor(target, dtype=flow.long), placement_idx=-1),
         )
         return data_sample

--- a/libai/evaluation/cls_evaluator.py
+++ b/libai/evaluation/cls_evaluator.py
@@ -56,9 +56,8 @@ class ClsEvaluator(DatasetEvaluator):
         self._predictions = []
 
     def process(self, inputs, outputs):
-        # FIX ME: support dict args, not implement in graph right now
-        pred_logits = outputs[-1]  # decide by your model output
-        labels = inputs[-1]  # decide by your dataloder output
+        pred_logits = outputs["prediction_scores"]
+        labels = inputs["label"]
 
         # measure accuracy
         acc1 = accuracy(pred_logits, labels, topk=1)
@@ -75,8 +74,8 @@ class ClsEvaluator(DatasetEvaluator):
         total_correct_num = 0
         total_samples = 0
         for prediction in predictions:
-            total_correct_num += prediction["num_correct"]
-            total_samples += prediction["num_samples"]
+            total_correct_num += int(prediction["num_correct"])
+            total_samples += int(prediction["num_samples"])
 
         acc1 = total_correct_num / total_samples * 100
 

--- a/libai/evaluation/evaluator.py
+++ b/libai/evaluation/evaluator.py
@@ -17,6 +17,7 @@ import datetime
 import logging
 import time
 from collections import OrderedDict, abc
+from contextlib import ExitStack, contextmanager
 from typing import Callable, List, Union
 
 import oneflow as flow
@@ -148,7 +149,12 @@ def inference_on_dataset(
     total_compute_time = 0
     total_eval_time = 0
     consumed_samples = 0
-    with flow.no_grad():
+    dps = dist.get_data_parallel_size()
+    last_batch_lack = (dps - (total % dps)) % dps
+    with ExitStack() as stack:
+        if isinstance(model, (flow.nn.Module, flow.nn.Graph)):
+            stack.enter_context(inference_context(model))
+        stack.enter_context(flow.no_grad())
 
         start_data_time = time.perf_counter()
         for idx, inputs in enumerate(data_loader):
@@ -162,16 +168,13 @@ def inference_on_dataset(
             start_compute_time = time.perf_counter()
             # model forward
             data = get_batch(inputs)
-            paded_data, valid_sample = pad_batch(data, batch_size)
-            outputs = model(*paded_data)
-            # TODO(chengpeng): Slice valid_samples
-            valid_data = [d[:valid_sample] for d in data]
-            if isinstance(outputs, (list, tuple)):
-                valid_outputs = [op[:valid_sample] for op in outputs]
-            elif isinstance(outputs, flow.Tensor):
-                valid_outputs = [outputs[:valid_sample]]
-            else:
-                raise NotImplementedError(f"model output type {type(outputs)} is not supported")
+            is_last_batch = idx == len(data_loader) - 1
+            paded_data, valid_sample = pad_batch(data, batch_size, last_batch_lack, is_last_batch)
+            outputs = model(**paded_data)
+
+            # get valid sample
+            valid_data = {key: value[:valid_sample] for key, value in data.items()}
+            valid_outputs = {key: value[:valid_sample] for key, value in outputs.items()}
 
             if flow.cuda.is_available():
                 dist.synchronize()
@@ -209,6 +212,7 @@ def inference_on_dataset(
     total_time = time.perf_counter() - start_time
     total_time_str = str(datetime.timedelta(seconds=total_time))
     # NOTE this format is parsed by grep
+    logger.info("Total valid samples: {}".format(consumed_samples))
     logger.info(
         "Total inference time: {} ({:.6f} s / iter per device, on {} devices)".format(
             total_time_str, total_time / (total - num_warmup), num_devices
@@ -229,3 +233,23 @@ def inference_on_dataset(
     if results is None:
         results = {}
     return results
+
+
+@contextmanager
+def inference_context(model):
+    """
+    A context where the model is temporarily changed to eval mode,
+    and restored to previous mode afterwards.
+    Args:
+        model: eager or graph mode in oneflow
+    """
+    training_mode = model.model.training if isinstance(model, flow.nn.Graph) else model.training
+    if isinstance(model, flow.nn.Graph):
+        model.model.eval()
+    else:
+        model.eval()
+    yield
+    if isinstance(model, flow.nn.Graph):
+        model.model.train(training_mode)
+    else:
+        model.train(training_mode)

--- a/libai/evaluation/utils.py
+++ b/libai/evaluation/utils.py
@@ -18,25 +18,35 @@ from collections.abc import Mapping
 
 import oneflow as flow
 
+from libai.utils import distributed as dist
 
-def pad_batch(x_list, batch_size):
-    x = x_list[0]
-    valid_sample = x.shape[0]
-    assert valid_sample <= batch_size
-    # check all batch size is equal
-    for xi in x_list[1:]:
-        assert xi.shape[0] == valid_sample
 
-    if valid_sample == batch_size:
-        return x_list, batch_size
-    # pad all data
-    padded_list = []
-    for xi in x_list:
+def pad_batch(x_dict, batch_size, last_batch_lack, ls_last_batch):
+    x = list(x_dict.values())[0]
+    tensor_batch = x.shape[0]
+    assert tensor_batch <= batch_size
+
+    if tensor_batch == batch_size and not ls_last_batch:
+        return x_dict, batch_size
+
+    valid_sample = tensor_batch - last_batch_lack
+    data_parallel_size = dist.get_data_parallel_size()
+    assert tensor_batch % data_parallel_size == 0
+    tensor_micro_batch_size = tensor_batch // data_parallel_size
+    padded_dict = {}
+    for key, xi in x_dict.items():
         pad_shape = (batch_size, *xi.shape[1:])
         padded_xi = flow.zeros(pad_shape, sbp=xi.sbp, placement=xi.placement, dtype=xi.dtype)
-        padded_xi[:valid_sample, ...] = padded_xi[:valid_sample, ...] + xi
-        padded_list.append(padded_xi)
-    return padded_list, valid_sample
+        padded_xi[:tensor_batch, ...] = padded_xi[:tensor_batch, ...] + xi
+        padded_xi = padded_xi.to_global(
+            sbp=dist.get_nd_sbp([flow.sbp.broadcast, flow.sbp.broadcast])
+        )
+        for i in range(last_batch_lack - 1):
+            start_idx = tensor_micro_batch_size * (data_parallel_size - i - 1) - 1
+            padded_xi[start_idx:-1] = padded_xi[start_idx + 1 :]
+        padded_xi = padded_xi.to_global(sbp=xi.sbp)
+        padded_dict[key] = padded_xi
+    return padded_dict, valid_sample
 
 
 def print_csv_format(results):

--- a/libai/layers/layer_norm.py
+++ b/libai/layers/layer_norm.py
@@ -25,12 +25,11 @@ class LayerNorm(nn.Module):
     Arguments:
         normalized_shape: input shape from an expected input of size.
         eps: a value added to the denominator for numerical stability. Defaults to 1e-5.
-        elementwise_affine: a boolean value that when set to ``True``, this module
-        has learnable per-element affine parameters initialized to ones (for weights) and zeros
-        (for biases). Default: ``True``.
-
+            elementwise_affine: a boolean value that when set to ``True``, this module
+            has learnable per-element affine parameters initialized to ones (for weights)
+            and zeros (for biases). Default: ``True``.
         layer_idx: A layer_idx sign which determines the placement. It will be used in pipeline
-        parallelism. Defaults to 0.
+            parallelism. Defaults to 0.
     """
 
     def __init__(self, normalized_shape, eps=1e-5, elementwise_affine=True, *, layer_idx=0):

--- a/libai/layers/linear.py
+++ b/libai/layers/linear.py
@@ -21,7 +21,7 @@ from libai.utils import distributed as dist
 
 
 class Linear1D(nn.Module):
-    """Linear layer with 1D parallelism which includes column parallelism and row parallelism.
+    r"""Linear layer with 1D parallelism which includes column parallelism and row parallelism.
     The linear layer is defined as :math:`Y = XA + b`.
 
     In column parallelism, A is parallelized along the second dimension
@@ -29,22 +29,29 @@ class Linear1D(nn.Module):
 
     In row parallelism, A is parallelized along the first dimension and X along its second
     dimension as:
-                | A_1 |
-                |  .  |
-            A = |  .  |         X = [X_1, ..., X_p]
-                |  .  |
-                | A_p |
+
+    .. math::
+        A = \begin{bmatrix}
+                 A\_1 \\
+                 . \\
+                 . \\
+                 . \\
+                 A\_p
+        \end{bmatrix}
+        x = \begin{bmatrix}
+                 x\_1 & ... & x\_p
+        \end{bmatrix}
 
     Arguments:
         in_features: size of each input sample.
         out_features: size of each output sample.
         bias: If set to ``False``, the layer will not learn an additive bias. Defaults to ``True``.
-        parallel: . Defaults to "data".
-        init_method: method to initialize weight. Defaults to nn.init.xavier_normal_.
+        parallel: Parallel mode. Defaults to "data".
+        init_method: method to initialize weight. Defaults to :func:`nn.init.xavier_normal_`.
         skip_bias_add: skip adding bias but instead return it, so that adding bias can be fused with
-        other elementwise operations. Defaults to ``False``.
+            other elementwise operations. Defaults to ``False``.
         layer_idx: A layer_idx sign which determines the placement. It will be used in pipeline
-        parallelism. Defaults to 0.
+            parallelism. Defaults to 0.
     """
 
     def __init__(

--- a/libai/layers/mlp.py
+++ b/libai/layers/mlp.py
@@ -31,15 +31,15 @@ class MLP(nn.Module):
         ffn_hidden_size: size of each intermediate sample.
         output_dropout_prob: Output dropout probability. Defaults to 0.0.
         init_method: method to initialize the first linear weight.
-        Defaults to nn.init.xavier_normal_.
+            Defaults to :func:`nn.init.xavier_normal_`.
         output_layer_init_method: method to initialize the second linear weight. If set to None,
-        it will use ``init_method`` instead. Defaults to None.
+            it will use ``init_method`` instead. Defaults to None.
         bias_gelu_fusion: If set to ``True``, it will fuse bias adding and elementwise
-        gelu activation. Defaults to ``False``.
+            gelu activation. Defaults to ``False``.
         bias_dropout_fusion: If set to ``True``, it will fuse bias adding and dropout.
-        Defaults to ``False``.
+            Defaults to ``False``.
         layer_idx: A layer_idx sign which determines the placement. It will be used in
-        pipeline parallelism. Defaults to 0.
+            pipeline parallelism. Defaults to 0.
     """
 
     def __init__(

--- a/libai/layers/transformer_layer.py
+++ b/libai/layers/transformer_layer.py
@@ -34,19 +34,34 @@ class TransformerLayer(nn.Module):
         ffn_hidden_size: size of feed forword neural network.
         num_attention_heads: number of attention heads.
         is_decoder: used to specify whether this is transformer encoder layer or transformer
-        decoder layer. Default: ``False``.
+            decoder layer. Default: ``False``.
         attention_dropout_prob: dropout probability of attention weights.
         output_dropout_prob: dropout probability of output.
         layernorm_epsilon: epsilon used in layernorm layer. Default: `1e-5`.
         init_method: method to initialize the input layer weights.
         output_layer_init_method: method to initialize the output layer weights.
-        If None, use `init_method`.
+            If None, use `init_method`.
         bias_gelu_fusion: whether fuse add bias and gelu. Default: ``False``.
         bias_dropout_fusion: whether fuse add bias and dropout. Default: ``False``.
         scale_mask_softmax_fusion: whether to fuse scale, mask and softmax. Default: ``False``.
         apply_query_key_layer_scaling: if `true`, scaling the attention score by layer index.
-        Default: ``False``.
+            Default: ``False``.
         layer_idx: the layer index, which determines the placement.
+
+    Inputs:
+        * **hidden_states**: [bsz, seq_length, hidden_size], (S(0), B).
+        * **attention_mask**: [bsz, 1, seq_length, seq_length], (S(0), B),
+          the combination of key padding mask and casual mask of hidden states.
+        * **encoder_states**: [bsz, seq_length, hidden_size], (S(0), B), encoder output,
+          this will be used in cross attention.
+        * **encoder_attention_mask**: [bsz, 1, seq_length, seq_length],
+          (S(0), B) key padding mask of encoder states.
+        * **past_key_value**: tuple of key and value, each shape is
+          [src_len, bsz, num_heads, head_size], For decoder layer,
+          the past_key_value contains the states both from
+          self attention and cross attention.
+        * **use_cache**: it will be set to `True`, when the model is in the inference phase and
+          used for incremental decoding.
     """
 
     def __init__(
@@ -123,20 +138,6 @@ class TransformerLayer(nn.Module):
         past_key_value=None,
         use_cache=False,
     ):
-        """
-        hidden_states: [bsz, seq_length, hidden_size], (S(0), B),
-        attention_mask: [bsz, 1, seq_length, seq_length], (S(0), B),
-        the combination of key padding mask and casual mask of hidden states.
-        encoder_states: [bsz, seq_length, hidden_size], (S(0), B), encoder output,
-        this will be used in cross attention.
-        encoder_attention_mask: [bsz, 1, seq_length, seq_length],
-        (S(0), B) key padding mask of encoder states.
-        past_key_value: tuple of key and value, each shape is [src_len, bsz, num_heads, head_size].
-        For decoder layer, the past_key_value contains the states both
-        from self attention and cross attention.
-        use_cache: it will be set to `True`, when the model is in the inference phase and
-        used for incremental decoding.
-        """
         # Change placement for pipeline parallelsim
         hidden_states = hidden_states.to_global(placement=dist.get_layer_placement(self.layer_idx))
 

--- a/libai/models/bert_model.py
+++ b/libai/models/bert_model.py
@@ -341,7 +341,7 @@ class BertPreTrainingHeads(nn.Module):
         seq_relationship_score = self.seq_relationship(pooled_output)
         prediction_scores = self.lm_logits(prediction_scores, word_embeddings_weight)
 
-        if lm_labels is not None:
+        if self.training and lm_labels is not None:
             return self.loss_func(
                 prediction_scores, lm_labels, loss_mask, seq_relationship_score, ns_labels
             )

--- a/libai/models/vision_transformer.py
+++ b/libai/models/vision_transformer.py
@@ -300,7 +300,7 @@ class VisionTransformer(nn.Module):
                 dim=1,
             )
         pos_embed = self.pos_embed.expand(x.shape[0], -1, -1)
-        pos_embed = pos_embed.to_consistent(sbp=flow.sbp.split(0), placement=pos_embed.placement)
+        pos_embed = pos_embed.to_global(sbp=flow.sbp.split(0), placement=pos_embed.placement)
         x = self.pos_drop(x + self.pos_embed)
         # transformer encoder
         x = self.blocks(x)

--- a/libai/models/vision_transformer.py
+++ b/libai/models/vision_transformer.py
@@ -311,7 +311,7 @@ class VisionTransformer(nn.Module):
         else:
             return x[:, 0], x[:, 1]
 
-    def forward(self, images, targets=None):
+    def forward(self, images, label=None):
         x = self.forward_features(images)
         # classification head
         if self.head_dist is not None:
@@ -324,11 +324,11 @@ class VisionTransformer(nn.Module):
         else:
             x = self.head(x)
 
-        if targets is not None:
-            losses = self.loss_func(x, targets)
+        if label is not None and self.training:
+            losses = self.loss_func(x, label)
             return {"losses": losses}
         else:
-            return {"logits": x}
+            return {"prediction_scores": x}
 
 
 def _init_vit_weights(

--- a/libai/models/vision_transformer.py
+++ b/libai/models/vision_transformer.py
@@ -299,10 +299,8 @@ class VisionTransformer(nn.Module):
                 ),
                 dim=1,
             )
-        self.pos_embed = self.pos_embed.expand(x.shape[0], -1, -1)
-        self.pos_embed = self.pos_embed.to_global(
-            sbp=flow.sbp.split(0), placement=self.pos_embed.placement
-        )
+        pos_embed = self.pos_embed.expand(x.shape[0], -1, -1)
+        pos_embed = pos_embed.to_consistent(sbp=flow.sbp.split(0), placement=pos_embed.placement)
         x = self.pos_drop(x + self.pos_embed)
         # transformer encoder
         x = self.blocks(x)
@@ -313,8 +311,8 @@ class VisionTransformer(nn.Module):
         else:
             return x[:, 0], x[:, 1]
 
-    def forward(self, x, targets=None):
-        x = self.forward_features(x)
+    def forward(self, images, targets=None):
+        x = self.forward_features(images)
         # classification head
         if self.head_dist is not None:
             x, x_dist = self.head(x[0]), self.head_dist(x[1])  # x must be a tuple
@@ -328,9 +326,9 @@ class VisionTransformer(nn.Module):
 
         if targets is not None:
             losses = self.loss_func(x, targets)
-            return losses
+            return {"losses": losses}
         else:
-            return x
+            return {"logits": x}
 
 
 def _init_vit_weights(

--- a/libai/scheduler/__init__.py
+++ b/libai/scheduler/__init__.py
@@ -19,5 +19,5 @@ from .lr_scheduler import (
     WarmupCosineLR,
     WarmupExponentialLR,
     WarmupMultiStepLR,
-    WarmupPolynomailLR,
+    WarmupPolynomialLR,
 )

--- a/libai/scheduler/lr_scheduler.py
+++ b/libai/scheduler/lr_scheduler.py
@@ -31,6 +31,21 @@ def WarmupCosineLR(
     alpha: float = 0.0,
     warmup_method: str = "linear",
 ):
+    """Create a schedule with a learning rate that decreases following
+    the values of the Cosine function between the initial lr set in the
+    optimizer to 0, after a warmup period during which it increases linearly
+    between 0 and the initial lr set in the optimizer.
+
+    Args:
+        optimizer (flow.optim.Optimizer): Wrapped optimizer.
+        max_iter (int): Total training iters.
+        warmup_factor (float): The warmup factor.
+        warmup_iter (int): The number of warmup steps.
+        alpha (float, optional): The learning rate scale factor (:math:`\\alpha`). Defaults to 0.0.
+        warmup_method (str, optional): The method of warmup, you can choose "linear" or "constant".
+            In linear mode, the multiplication factor starts with warmup_factor in
+            the first epoch and then inreases linearly to reach 1. Defaults to "linear".
+    """
     cosine_decay_lr = flow.optim.lr_scheduler.CosineDecayLR(
         optimizer, decay_steps=max_iter, alpha=alpha
     )
@@ -57,6 +72,21 @@ def WarmupCosineAnnealingLR(
     eta_min: float = 0.0,
     warmup_method: str = "linear",
 ):
+    """Create a schedule with a learning rate that decreases following
+    the values of the Cosine Annealing function between the initial
+    lr set in the optimizer to 0, after a warmup period during which
+    it increases linearly between 0 and the initial lr set in the optimizer.
+
+    Args:
+        optimizer (flow.optim.Optimizer): Wrapped optimizer.
+        max_iter (int): Total training iters.
+        warmup_factor (float): The warmup factor.
+        warmup_iter (int): The number of warmup steps.
+        eta_min (float, optional): Minimum learning rate. Defaults to 0.0.
+        warmup_method (str, optional): The method of warmup, you can choose "linear" or "constant".
+            In linear mode, the multiplication factor starts with warmup_factor in the first epoch
+            and then inreases linearly to reach 1. Defaults to "linear".
+    """
     cosine_annealing_lr = flow.optim.lr_scheduler.CosineAnnealingLR(
         optimizer, T_max=max_iter, eta_min=eta_min
     )
@@ -82,6 +112,21 @@ def WarmupMultiStepLR(
     gamma: float = 0.1,
     warmup_method: str = "linear",
 ):
+    """Create a schedule with a learning rate that decreases following the values of the MultiStep
+    function between the initial lr set in the optimizer to 0, after a warmup period during which
+    it increases linearly between 0 and the initial lr set in the optimizer.
+
+    Args:
+        optimizer (flow.optim.Optimizer): Wrapped optimizer.
+        max_iter (int): Total training iters.
+        warmup_factor (float): The warmup factor.
+        warmup_iter (int): The number of warmup steps.
+        milestones (list): List of step indices. Must be increasing.
+        gamma (float, optional): Multiplicative factor of learning rate decay. Defaults to 0.1.
+        warmup_method (str, optional): The method of warmup, you can choose "linear" or "constant".
+            In linear mode, the multiplication factor starts with warmup_factor in the first
+            epoch and then inreases linearly to reach 1. Defaults to "linear".
+    """
     multistep_lr = flow.optim.lr_scheduler.MultiStepLR(
         optimizer, milestones=milestones, gamma=gamma
     )
@@ -106,6 +151,21 @@ def WarmupExponentialLR(
     warmup_iter: int,
     warmup_method: str = "linear",
 ):
+    """Create a schedule with a learning rate that decreases following the values of
+    the Exponential function between the initial lr set in the optimizer to 0,
+    after a warmup period during which it increases linearly between 0 and the
+    initial lr set in the optimizer.
+
+    Args:
+        optimizer (flow.optim.Optimizer): Wrapped optimizer.
+        max_iter (int): Total training iters.
+        gamma (float): Multiplicative factor of learning rate decay.
+        warmup_factor (float): The warmup factor.
+        warmup_iter (int): The number of warmup steps.
+        warmup_method (str, optional): The method of warmup, you can choose "linear" or "constant".
+            In linear mode, the multiplication factor starts with warmup_factor in the first epoch
+            and then inreases linearly to reach 1. Defaults to "linear".
+    """
     exponential_lr = flow.optim.lr_scheduler.ExponentialLR(optimizer, gamma=gamma)
     if warmup_iter == 0:
         logger.warning("warmup iters equals to zero, return ExponentialLR")
@@ -120,7 +180,7 @@ def WarmupExponentialLR(
 
 
 @SCHEDULER_REGISTRY.register()
-def WarmupPolynomailLR(
+def WarmupPolynomialLR(
     optimizer: flow.optim.Optimizer,
     max_iter: int,
     warmup_factor: float,
@@ -130,6 +190,25 @@ def WarmupPolynomailLR(
     cycle: bool = False,
     warmup_method: str = "linear",
 ):
+    """Create a schedule with a learning rate that decreases as a polynomial decay from
+    the initial lr set in the optimizer to end lr defined by `lr_end`,
+    after a warmup period during which it increases linearly from 0 to the
+    initial lr set in the optimizer.
+
+
+    Args:
+        optimizer (flow.optim.Optimizer): Wrapped optimizer.
+        max_iter (int): Total training iters.
+        warmup_factor (float): The warmup factor.
+        warmup_iter (int): The number of warmup steps.
+        end_learning_rate (float, optional): The final learning rate. Defaults to 0.0001.
+        power (float, optional): The power of polynomial. Defaults to 1.0.
+        cycle (bool, optional): If cycle is True, the scheduler will decay the learning rate
+            every decay steps. Defaults to False.
+        warmup_method (str, optional): The method of warmup, you can choose "linear" or "constant".
+            In linear mode, the multiplication factor starts with warmup_factor in the first
+            epoch and then inreases linearly to reach 1. Defaults to "linear".
+    """
     polynomial_lr = flow.optim.lr_scheduler.PolynomialLR(
         optimizer, steps=max_iter, end_learning_rate=end_learning_rate, power=power, cycle=cycle
     )

--- a/libai/tokenizer/tokenization_bert.py
+++ b/libai/tokenizer/tokenization_bert.py
@@ -84,6 +84,27 @@ def _is_chinese_substr(char):
 class BertTokenizer(PreTrainedTokenizer):
     """
     Construct a BERT tokenizer. Based on WordPiece.
+
+    Args:
+        vocab_file (:obj:`str`):
+            Path to a one-wordpiece-per-line vocabulary file.
+        do_lower_case (:obj:`bool`, `optional`, defaults to :obj:`True`):
+            Whether to lower case the input
+            Only has an effect when do_basic_tokenize=True.
+        do_basic_tokenize (:obj:`bool`, `optional`, defaults to :obj:`True`):
+            Whether to do basic tokenization before wordpiece.
+        never_split (:obj:`Iterable`, `optional`):
+            List of tokens which will never be split during tokenization.
+            Only has an effect when do_basic_tokenize=True.
+        tokenize_chinese_chars (:obj:`bool`, `optional`, defaults to :obj:`True`):
+            Whether to tokenize Chinese characters.
+            This should likely be deactivated for Japanese,
+            see: https://github.com/huggingface/pytorch-pretrained-BERT/issues/328.
+        do_chinese_wwm (:obj:`bool`, `optional`, defaults to :obj:`False`):
+            Whether to do whole word masking for Chinese.
+            Chinese sentence will be segmented by a third-party tool first.
+            Each substr will be added '##' prefix and its index will be calucated by
+            id(##A) = id(A) + vocab_size.
     """
 
     vocab_files_names = VOCAB_FILES_NAMES
@@ -106,27 +127,6 @@ class BertTokenizer(PreTrainedTokenizer):
         do_chinese_wwm=False,
         **kwargs,
     ):
-        """Constructs a BertTokenizer.
-        Args:
-            **vocab_file**: Path to a one-wordpiece-per-line vocabulary file
-            **do_lower_case**: (`optional`) boolean (default True)
-                Whether to lower case the input
-                Only has an effect when do_basic_tokenize=True
-            **do_basic_tokenize**: (`optional`) boolean (default True)
-                Whether to do basic tokenization before wordpiece.
-            **never_split**: (`optional`) list of string
-                List of tokens which will never be split during tokenization.
-                Only has an effect when do_basic_tokenize=True
-            **tokenize_chinese_chars**: (`optional`) boolean (default True)
-                Whether to tokenize Chinese characters.
-                This should likely be deactivated for Japanese:
-                see: https://github.com/huggingface/pytorch-pretrained-BERT/issues/328
-            **do_chinese_wwm**: (`optional`) boolean (default False)
-                Whether to do whole word masking for Chinese.
-                Chinese sentence will be segmented by a third-party tool first.
-                Each substr will be added '##' prefix and its index will be calucated by
-                id(##A) = id(A) + vocab_size.
-        """
         super(BertTokenizer, self).__init__(
             unk_token=unk_token,
             sep_token=sep_token,

--- a/libai/tokenizer/tokenization_gpt2.py
+++ b/libai/tokenizer/tokenization_gpt2.py
@@ -89,6 +89,22 @@ def get_pairs(word):
 class GPT2Tokenizer(PreTrainedTokenizer):
     """
     Construct a GPT-2 tokenizer. Based on byte-level Byte-Pair-Encoding.
+
+    Args:
+        vocab_file (:obj:`str`):
+            Path to the vocabulary file.
+        merges_file (:obj:`str`):
+            Path to the merges file.
+        errors (:obj:`str`, `optional`, defaults to :obj:`"replace"`):
+            Paradigm to follow when decoding bytes to UTF-8. See `bytes.decode
+            <https://docs.python.org/3/library/stdtypes.html#bytes.decode>`__ for more information.
+        unk_token (:obj:`str`, `optional`, defaults to :obj:`<|endoftext|>`):
+            The unknown token. A token that is not in the vocabulary cannot be
+            converted to an ID and is set to be this token instead.
+        bos_token (:obj:`str`, `optional`, defaults to :obj:`<|endoftext|>`):
+            The beginning of sequence token.
+        eos_token (:obj:`str`, `optional`, defaults to :obj:`<|endoftext|>`):
+            The end of sequence token.
     """
 
     vocab_files_names = VOCAB_FILES_NAMES

--- a/libai/tokenizer/tokenization_t5.py
+++ b/libai/tokenizer/tokenization_t5.py
@@ -42,6 +42,27 @@ PRETRAINED_POSITIONAL_EMBEDDINGS_SIZES = {
 class T5Tokenizer(PreTrainedTokenizer):
     """
     Construct a T5 tokenizer. Based on `SentencePiece <https://github.com/google/sentencepiece>`.
+
+    Args:
+        vocab_file (:obj:`str`):
+            Path to the vocabulary file.
+        eos_token (:obj:`str`, `optional`, defaults to :obj:`"</s>"`):
+            The end of sequence token.
+        unk_token (:obj:`str`, `optional`, defaults to :obj:`"<unk>"`):
+            The unknown token. A token that is not in the vocabulary cannot
+            be converted to an ID and is set to be this token instead.
+        pad_token (:obj:`str`, `optional`, defaults to :obj:`"<pad>"`):
+            The token used for padding, for example when batching sequences of different lengths.
+        extra_ids (:obj:`int`, `optional`, defaults to 100):
+            Add a number of extra ids added to the end of the vocabulary for use
+            as sentinels. These tokens are accessible as "<extra_id_{%d}>" where
+            "{%d}" is a number between 0 and extra_ids-1. Extra tokens are indexed
+            from the end of the vocabulary up to beginning ("<extra_id_0>" is the
+            last token in the vocabulary like in T5 preprocessing see `here
+            <https://github.com/google-research/text-to-text-transfer-transformer/blob/9fd7b14a769417be33bc6c850f9598764913c833/t5/data/preprocessors.py#L2117>`__).
+        additional_special_tokens (:obj:`List[str]`, `optional`):
+            Additional special tokens used by the tokenizer.
+
     """
 
     vocab_files_names = VOCAB_FILES_NAMES

--- a/libai/trainer/default.py
+++ b/libai/trainer/default.py
@@ -372,9 +372,9 @@ class DefaultTrainer(TrainerBase):
             data.reraise()
 
         if mixup_func is not None:
-            images, targets = mixup_func(data.get("images").tensor, data.get("targets").tensor)
+            images, label = mixup_func(data.get("images").tensor, data.get("label").tensor)
             data.get("images").tensor = images
-            data.get("targets").tensor = targets
+            data.get("label").tensor = label
 
         ret_dict = {}
         for key, value in data.get_fields().items():

--- a/libai/trainer/default.py
+++ b/libai/trainer/default.py
@@ -542,7 +542,7 @@ class DefaultTrainer(TrainerBase):
             log_info += f", scheduler milestones={cfg.train.scheduler.milestones}"
         logger.info(log_info)
 
-        # Consistent scheduler cfg
+        # Global scheduler cfg
         cfg.train.scheduler.warmup_iter = cfg.train.warmup_iter
         cfg.train.scheduler.max_iter = cfg.train.train_iter
 
@@ -576,7 +576,7 @@ class DefaultTrainer(TrainerBase):
         for idx, data_loader in enumerate(test_loaders):
             # When evaluators are passed in as arguments,
             # implicitly assume that evaluators can be created before data_loader.
-            dataset_name = getattr(data_loader.dataset, "datasetname", "UndefinedDataset")
+            dataset_name = getattr(data_loader.dataset, "dataset_name", "UndefinedDataset")
             # TODO: support multi evaluator
             # if evaluators is not None:
             #     evaluator = evaluators[idx]

--- a/libai/utils/checkpoint.py
+++ b/libai/utils/checkpoint.py
@@ -111,7 +111,7 @@ class Checkpointer(object):
             if self.path_manager.exists(save_file):
                 self.path_manager.mkdirs(save_file)
 
-            flow.save(data[save_name], save_file, consistent_dst_rank=0)
+            flow.save(data[save_name], save_file, global_dst_rank=0)
 
         self.tag_last_checkpoint(basename)
 
@@ -281,8 +281,8 @@ class Checkpointer(object):
             v = state_dict[k]
             if not isinstance(v, np.ndarray) and not isinstance(v, flow.Tensor):
                 raise ValueError("Unsupported type found in checkpoint! {}: {}".format(k, type(v)))
-            # If it's local tensor, convert it to consistent tensor.
-            if not v.is_consistent:
+            # If it's local tensor, convert it to global tensor.
+            if not v.is_global:
                 if k in self.model.state_dict():
                     model_v = self.model.state_dict()[k]
                     state_dict[k] = v.to_global(sbp=model_v.sbp, placement=model_v.placement)

--- a/libai/utils/distributed.py
+++ b/libai/utils/distributed.py
@@ -306,10 +306,10 @@ def get_world_size():
 def convert_to_distributed_default_setting(module):
     """
     Helper function to convert all eager local tensor in :attr:`nn.Module` in the model to
-        consistent tensor with data parallelism as default.
+        global tensor with data parallelism as default.
     """
     for param in module.parameters():
-        if not param.is_consistent:
+        if not param.is_global:
             module.to_global(
                 sbp=get_nd_sbp([flow.sbp.broadcast, flow.sbp.broadcast]),
                 placement=get_layer_placement(0),
@@ -322,8 +322,8 @@ def get_num_nodes():
 
 
 def ttol(tensor, pure_local=False):
-    """consistent tensor to local tensor"""
-    if tensor.is_consistent:
+    """global tensor to local tensor"""
+    if tensor.is_global:
         if pure_local:
             tensor = tensor.to_local()
         else:
@@ -335,8 +335,8 @@ def ttol(tensor, pure_local=False):
 
 
 def tton(tensor, local_only=False):
-    """consistent tensor to numpy"""
-    if tensor.is_consistent:
+    """global tensor to numpy"""
+    if tensor.is_global:
         tensor = ttol(tensor, local_only)
 
     return tensor.numpy()

--- a/projects/QQP/configs/config_qqp.py
+++ b/projects/QQP/configs/config_qqp.py
@@ -4,16 +4,18 @@ from configs.common.data.bert_dataset import tokenization
 from configs.common.models.bert import cfg as qqp_cfg
 from configs.common.optim import optim
 from configs.common.train import train
+from configs.common.models.graph import graph
 from libai.config import LazyCall
 from libai.data.build import build_nlp_test_loader, build_nlp_train_loader
 from projects.QQP.dataset.qqp_dataset import QQPDataset
-from projects.QQP.modeling.model import Classification, ClassificationGraph
+from projects.QQP.modeling.model import Classification
 from projects.QQP.tokenizer.tokenizer import _BertCNWWMTokenizer
 
 tokenization.tokenizer = LazyCall(_BertCNWWMTokenizer)(
     vocab_file="/home/chengpeng/data/PrimeLM/data/bert-base-chinese-vocab.txt",
     lower_case=True,
 )
+tokenization.setup = True
 tokenization.append_eod = False
 tokenization.make_vocab_size_divisible_by = 128
 
@@ -21,8 +23,8 @@ dataloader = OmegaConf.create()
 dataloader.train = LazyCall(build_nlp_train_loader)(
     dataset=[
         LazyCall(QQPDataset)(
-            name="QQP_TRAIN",
-            datapaths=[
+            dataset_name="QQP_TRAIN",
+            data_paths=[
                 "/home/chengpeng/train.tsv",
             ],
             max_seq_length=512,
@@ -33,8 +35,8 @@ dataloader.train = LazyCall(build_nlp_train_loader)(
 dataloader.test = [
     LazyCall(build_nlp_test_loader)(
         dataset=LazyCall(QQPDataset)(
-            name="QQP_TEST",
-            datapaths=[
+            dataset_name="QQP_TEST",
+            data_paths=[
                 "/home/chengpeng/dev.tsv",
             ],
             max_seq_length=512,
@@ -57,30 +59,25 @@ qqp_cfg.update(
 )
 model = LazyCall(Classification)(cfg=qqp_cfg)
 
+optim.lr = 1e-6
+optim.weight_decay = 0.1
+
 train.update(
     dict(
         recompute_grad=dict(enabled=True),
+        amp=dict(enabled=True),
         output_dir="output/finetune_qqp/",
         train_micro_batch_size=16,
-        test_micro_batch_size=2,
+        test_micro_batch_size=4,
         train_epoch=1,
         train_iter=0,
         eval_period=100,
         log_period=10,
+        warmup_ratio=0.01,
         dist=dict(
             data_parallel_size=1,
             tensor_parallel_size=1,
             pipeline_parallel_size=1,
         ),
     )
-)
-
-graph = dict(
-    enabled=True,
-    train_graph=LazyCall(ClassificationGraph)(
-        is_train=True,
-        recompute_grad=True,
-        fp16=True,
-    ),
-    eval_graph=LazyCall(ClassificationGraph)(is_train=False, fp16=True),
 )

--- a/projects/QQP/dataset/data_utils.py
+++ b/projects/QQP/dataset/data_utils.py
@@ -39,9 +39,9 @@ def build_sample(ids, types, paddings, label, unique_id):
     types_np = np.array(types, dtype=np.int64)
     paddings_np = np.array(paddings, dtype=np.int64)
     sample = Instance(
-        text=DistTensorData(flow.tensor(ids_np, dtype=flow.long), placement_idx=0),
-        padding_mask=DistTensorData(flow.tensor(paddings_np, dtype=flow.long), placement_idx=0),
-        types=DistTensorData(flow.tensor(types_np, dtype=flow.long), placement_idx=0),
+        model_input=DistTensorData(flow.tensor(ids_np, dtype=flow.long), placement_idx=0),
+        attention_mask=DistTensorData(flow.tensor(paddings_np, dtype=flow.long), placement_idx=0),
+        tokentype_ids=DistTensorData(flow.tensor(types_np, dtype=flow.long), placement_idx=0),
         label=DistTensorData(flow.tensor(label, dtype=flow.long), placement_idx=-1),
     )
 

--- a/projects/QQP/dataset/qqp_dataset.py
+++ b/projects/QQP/dataset/qqp_dataset.py
@@ -24,9 +24,10 @@ LABELS = [0, 1]
 
 
 class QQPDataset(GLUEAbstractDataset):
-    def __init__(self, name, datapaths, tokenizer, max_seq_length, test_label=0):
+    def __init__(self, dataset_name, data_paths, tokenizer, max_seq_length, test_label=0):
         self.test_label = test_label
-        super().__init__("QQP", name, datapaths, tokenizer, max_seq_length)
+        self.dataset_name = dataset_name
+        super().__init__("QQP", dataset_name, data_paths, tokenizer, max_seq_length)
 
     def process_samples_from_single_path(self, filename):
         """ "Implement abstract method."""

--- a/projects/QQP/modeling/model.py
+++ b/projects/QQP/modeling/model.py
@@ -20,7 +20,7 @@ from oneflow import nn
 
 from libai.layers import Linear
 from libai.models.bert_model import BertModel
-from libai.models.utils import GraphBase, init_method_normal
+from libai.models.utils import init_method_normal
 from libai.utils import distributed as dist
 
 from .load_megatron_weight import load_megatron_bert
@@ -73,19 +73,8 @@ class Classification(nn.Module):
         # reshape
         classification_logits = classification_logits.view(-1, self.num_classes)
 
-        if label is not None:
+        if self.training and label is not None:
             loss = self.loss_func(classification_logits, label)
-            return loss
+            return {"total_loss": loss}
 
-        return classification_logits
-
-
-class ClassificationGraph(GraphBase):
-    def build(self, tokens, padding_mask, tokentype_ids, label=None):
-        if not self.is_train:
-            return self.model(tokens, padding_mask, tokentype_ids)
-        else:
-            losses = self.model(tokens, padding_mask, tokentype_ids, label)
-
-            losses.backward()
-            return losses
+        return {"prediction_scores": classification_logits}

--- a/tests/data/test_sampler.py
+++ b/tests/data/test_sampler.py
@@ -159,14 +159,14 @@ class TestSingleRoundSampler(unittest.TestCase):
 
     def test_single_sampler_multi_rank(self):
         sampler_rank0 = SingleRoundSampler(
-            list(range(100)),
+            list(range(101)),
             micro_batch_size=4,
             shuffle=False,
             data_parallel_rank=0,
             data_parallel_size=2,
         )
         sampler_rank1 = SingleRoundSampler(
-            list(range(100)),
+            list(range(101)),
             micro_batch_size=4,
             shuffle=False,
             data_parallel_rank=1,
@@ -185,8 +185,8 @@ class TestSingleRoundSampler(unittest.TestCase):
 
         # Padding 0 if it's not enough for a batch, otherwise `to_global`
         # will raise errors for imbalanced data shape in different ranks
-        self.assertEqual(sample_output_rank0, list(range(50)) + [0, 0])
-        self.assertEqual(sample_output_rank1, list(range(50, 100)) + [0, 0])
+        self.assertEqual(sample_output_rank0, list(range(51)))
+        self.assertEqual(sample_output_rank1, list(range(51, 101)) + [0])
 
 
 if __name__ == "__main__":

--- a/tests/models/test_vit.py
+++ b/tests/models/test_vit.py
@@ -1,0 +1,45 @@
+# coding=utf-8
+# Copyright 2021 The OneFlow Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest import TestCase
+
+import oneflow as flow
+
+import libai.utils.distributed as dist
+from configs.common.models.vit.vit_tiny_patch16_224 import model as vit_tiny_patch16_224
+from libai.config import instantiate
+
+
+@unittest.skip("Update CI Environments to run OneFlow on GPUs")
+class TestVisionTransformer(TestCase):
+    def test_vit_tiny_patch16_224(self):
+        random_input = flow.randn(1, 3, 224, 224).to_consistent(
+            sbp=dist.get_nd_sbp([flow.sbp.split(0), flow.sbp.broadcast]),
+            placement=flow.placement("cuda" if flow.cuda.is_available() else "cpu", {0: 0}),
+        )
+        targets = flow.zeros(1, dtype=flow.int64).to_consistent(
+            sbp=dist.get_nd_sbp([flow.sbp.split(0), flow.sbp.broadcast]),
+            placement=flow.placement("cuda" if flow.cuda.is_available() else "cpu", {0: 0}),
+        )
+        model = instantiate(vit_tiny_patch16_224)
+        model.apply(dist.convert_to_distributed_default_setting)
+        output_dict = model(random_input, targets)
+        loss = output_dict["losses"]
+        loss.backward()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -25,7 +25,7 @@ from libai.scheduler import (
     WarmupCosineLR,
     WarmupExponentialLR,
     WarmupMultiStepLR,
-    WarmupPolynomailLR,
+    WarmupPolynomialLR,
 )
 
 
@@ -122,7 +122,7 @@ class TestScheduler(TestCase):
         p = nn.Parameter(flow.zeros(0))
         opt = flow.optim.SGD([p], lr=5.0)
 
-        sched = WarmupPolynomailLR(
+        sched = WarmupPolynomialLR(
             optimizer=opt,
             max_iter=30,
             warmup_factor=0.001,

--- a/tools/train.sh
+++ b/tools/train.sh
@@ -5,8 +5,9 @@ GPUS=$2
 NODE=${NODE:-1}
 NODE_RANK=${NODE_RANK:-0}
 ADDR=${ADDR:-127.0.0.1}
+PORT=${PORT:-12345}
 
 python3 -m oneflow.distributed.launch \
---nproc_per_node $GPUS --nnodes $NODE --node_rank $NODE_RANK --master_addr $ADDR \
+--nproc_per_node $GPUS --nnodes $NODE --node_rank $NODE_RANK --master_addr $ADDR --master_port $PORT \
 tools/train_net.py \
 --config-file $CONFIG ${@:3}


### PR DESCRIPTION
此PR的目的是
- [x] 修复main分支下vit模型的cfg中的错误，并跑通vit模型
- [x] 添加vit系列模型的config文件, 并全部放到`/configs/common/model/vit/`下统一管理
- [x] 跑通新添加的cfg文件
- [x] 删除原来cfg中不必要的参数
- [x] 增加visiontransformer模型的test, 只需要添加`tiny`的测试即可，因为其他变种只修改了embed_dim等一些模型容量的参数，并没有修改模型本身