### PR TITLE
Support getting config from configs

### DIFF
--- a/libai/config/config.py
+++ b/libai/config/config.py
@@ -18,6 +18,7 @@ import inspect
 import os
 
 from omegaconf import OmegaConf
+import pkg_resources
 
 from .lazy import LazyConfig
 
@@ -184,8 +185,10 @@ def get_config(config_path):
     Returns:
         omegaconf.DictConfig: a config object
     """
-    cfg_file = os.path.join("configs", config_path)
+    cfg_file = pkg_resources.resource_filename(
+        "libai.config", os.path.join("configs", config_path)
+    )
     if not os.path.exists(cfg_file):
-        raise RuntimeError("{} not available in Model Zoo!".format(config_path))
+        raise RuntimeError("{} not available in LiBai configs!".format(config_path))
     cfg = LazyConfig.load(cfg_file)
     return cfg

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import glob
 import os
 import subprocess
 import sys
+import shutil
+from os import path
+from typing import List
 
 from setuptools import Extension, find_packages, setup
 
@@ -66,6 +70,34 @@ extensions = [
     ),
 ]
 
+
+def get_libai_configs() -> List[str]:
+    """
+    Return a list of configs to include in package for model zoo.
+    """
+    source_configs_dir = path.join(path.dirname(path.realpath(__file__)), "configs")
+    destination = path.join(
+        path.dirname(path.realpath(__file__)), "libai", "config", "configs"
+    )
+    # Symlink the config directory inside package to have a cleaner pip install.
+
+    # Remove stale symlink/directory from a previous build.
+    if path.exists(source_configs_dir):
+        if path.islink(destination):
+            os.unlink(destination)
+        elif path.isdir(destination):
+            shutil.rmtree(destination)
+
+    if not path.exists(destination):
+        try:
+            os.symlink(source_configs_dir, destination)
+        except OSError:
+            # Fall back to copying if symlink fails: ex. on Windows.
+            shutil.copytree(source_configs_dir, destination)
+    config_paths = glob.glob("configs/**/*.py", recursive=True)
+    return config_paths
+
+
 if __name__ == "__main__":
     print(f"Building wheel {package_name}-{version}")
 
@@ -85,6 +117,7 @@ if __name__ == "__main__":
         license=license,
         install_requires=requirements,
         packages=find_packages(),
+        package_data={"libai.config": get_libai_configs()},
         ext_modules=extensions,
         test_suite="tests",
     )


### PR DESCRIPTION
## TODO
这个PR要完成的功能是:
- [x] 可以通过`libai.config.get_config`这个接口直接得到外层`configs/`下的config文件

### Usage
- 首先本地安装
```python
pip install -e .
```
- 在有libai的环境下
```python
from libai.config import get_config
cfg = get_config("vit_imagenet.py")
cfg = get_config("common/train.py")
print(cfg)
```