### PR TITLE
quic fix cfg keyword error

### DIFF
--- a/libai/engine/default.py
+++ b/libai/engine/default.py
@@ -508,8 +508,11 @@ class DefaultTrainer(TrainerBase):
         assert try_get_key(cfg, "model") is not None, "cfg must contain `model` namespace"
         # Set model fp16 option because of embedding layer `white_identity` manual
         # insert for amp training if provided.
-        if try_get_key(cfg.model.cfg, "amp_enabled") is not None:
+        if try_get_key(cfg.model, "cfg.amp_enabled") is not None:
             cfg.model.cfg.amp_enabled = cfg.train.amp.enabled and cfg.graph.enabled
+        # In case some model define without cfg keyword.
+        elif try_get_key(cfg.model, "amp_enabled") is not None:
+            cfg.model.amp_enabled = cfg.train.amp.enabled and cfg.graph.enabled
         model = build_model(cfg.model)
         logger = logging.getLogger(__name__)
         logger.info("Model:\n{}".format(model))


### PR DESCRIPTION
vit 模块的定义中没有使用 cfg 而是直接定义的参数，这个 pr 修复这个问题