### PR TITLE
Support auto_parallel

### DIFF
--- a/configs/bert_large_pretrain.py
+++ b/configs/bert_large_pretrain.py
@@ -20,8 +20,8 @@ model.cfg.hidden_layers = 8
 
 train.train_micro_batch_size = 16
 
-train.amp.enabled = True
-train.activation_checkpoint.enabled = True
+train.amp.enabled = False
+train.activation_checkpoint.enabled = False
 
 train.evaluation.evaluator = LazyCall(PPLEvaluator)()
 

--- a/configs/common/models/graph.py
+++ b/configs/common/models/graph.py
@@ -6,6 +6,7 @@ graph = dict(
     # options for graph or eager mode
     enabled=True,
     debug=-1,  # debug mode for graph
+    auto_parallel=False,
     train_graph=LazyCall(GraphBase)(
         is_train=True,
     ),

--- a/libai/engine/trainer.py
+++ b/libai/engine/trainer.py
@@ -313,8 +313,11 @@ class GraphTrainer(TrainerBase):
         start = time.perf_counter()
 
         # If you want to do something with the data, you can wrap the dataloader.
-        data = next(self._data_loader_iter)
-        data = get_batch(data, getattr(self.data_loader, "mixup_func", None))
+        if not hasattr(self, "_data"):
+            data = next(self._data_loader_iter)
+            data = get_batch(data, getattr(self.data_loader, "mixup_func", None))
+            self._data = data
+        data = self._data
         data_time = time.perf_counter() - start
 
         # If you want to do something with the losses, you can wrap the model.

--- a/libai/models/build.py
+++ b/libai/models/build.py
@@ -26,6 +26,7 @@ def build_model(cfg):
 
 def build_graph(cfg, model, optimizer=None, lr_scheduler=None, is_train=False):
     """Build the `nn.Graph`, defined by ``cfg.graph``."""
+    auto_parallel=try_get_key(cfg, "graph.auto_parallel", default=False)
     if is_train:
         # Set train graph
         assert optimizer is not None, "optimizer must be set for train graph"
@@ -41,9 +42,11 @@ def build_graph(cfg, model, optimizer=None, lr_scheduler=None, is_train=False):
         graph.zero_optim = try_get_key(cfg, "train.zero_optimization.enabled", default=False)
         graph.zero_stage = try_get_key(cfg, "train.zero_optimization.stage", default=1)
         graph.grad_acc_steps = try_get_key(cfg, "train.num_accumulation_steps", default=1)
+        graph.auto_parallel = auto_parallel
         return instantiate(graph)
     else:
         # Set eval graph
         graph = cfg.graph.eval_graph
         graph.model = model
+        graph.auto_parallel = auto_parallel
         return instantiate(graph)

--- a/tools/train_net.py
+++ b/tools/train_net.py
@@ -13,6 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import oneflow as flow
+
+flow.boxing.nccl.enable_use_compute_stream(False)
+flow.boxing.nccl.enable_all_to_all(True)
+
 import logging
 import os
 import sys
@@ -24,6 +29,11 @@ from libai.utils.checkpoint import Checkpointer
 
 logger = logging.getLogger("libai." + __name__)
 
+@classmethod
+def test(cls, cfg, test_loaders, model, evaluator=None):
+    return {}
+
+DefaultTrainer.test = test
 
 def main(args):
     cfg = LazyConfig.load(args.config_file)


### PR DESCRIPTION
使用 oneflow 仓库 feat-auto_parallel 分支，通过配置 `graph.auto_parallel=False/True` 可以关闭/开启自动并行。

及 bert 为例，执行以下命令即可：

```shell
COST_RATIO=0.05 WAIT_TIME=1.65e4 AUTO_PARALLEL_TRANSFER_COST=1.65e4 \
    ./tools/train.sh tools/train_net.py configs/bert_large_pretrain.py 4 graph.auto_parallel=True
```