### PR TITLE
fix bugs in convert_to_distributed_default_setting

### DIFF
--- a/libai/utils/distributed.py
+++ b/libai/utils/distributed.py
@@ -354,8 +354,8 @@ def convert_to_distributed_default_setting(module):
     Helper function to convert all eager local tensor in :attr:`nn.Module` in the model to
     global tensor with data parallelism as default.
     """
-    for param in module.parameters():
-        if not param.is_global:
+    for _, v in module.state_dict().items():
+        if not v.is_global:
             module.to_global(
                 sbp=get_nd_sbp([flow.sbp.broadcast, flow.sbp.broadcast]),
                 placement=get_layer_placement(0),


### PR DESCRIPTION
该pr修复libai.utils.distributed.py中convert_to_distributed_default_setting函数无法转换模型中buffer参数为global的bug。

详情：
https://github.com/Oneflow-Inc/libai/issues/288#issuecomment-1153399767 

改正后可正常转换buffer参数，经过4卡 bash dev/model_test.sh测试无bug。