### PR TITLE
fix LayerNorm layer

### DIFF
--- a/libai/layers/layer_norm.py
+++ b/libai/layers/layer_norm.py
@@ -85,8 +85,8 @@ class LayerNorm(nn.Module):
         else:
             y = flow._C.layer_norm(
                 x,
-                begin_norm_axis=self.begin_norm_axis,
-                begin_params_axis=self.begin_params_axis,
+                begin_norm_axis=begin_norm_axis,
+                begin_params_axis=begin_params_axis,
                 epsilon=self.eps,
             )
         return y


### PR DESCRIPTION
修复一下LayerNorm，begin_norm_axis变量前不加self引用
`AttributeError: 'LayerNorm' object has no attribute 'begin_norm_axis'`