### PR TITLE
refine zero

### DIFF
--- a/libai/models/utils/graph_base.py
+++ b/libai/models/utils/graph_base.py
@@ -19,7 +19,6 @@ import oneflow as flow
 from oneflow import nn
 
 from libai.layers import TransformerLayer
-from libai.utils import distributed as dist
 
 logger = logging.getLogger(__name__)
 
@@ -69,8 +68,6 @@ class GraphBase(nn.Graph):
         self.config.allow_fuse_add_to_output(True)
         self.config.allow_fuse_model_update_ops(True)
         self.config.allow_fuse_cast_scale(True)
-
-        # dist_util = dist.get_dist_util()
 
         # auto_parallel
         if auto_parallel_conf is not None and auto_parallel_conf.enabled:

--- a/libai/models/utils/graph_base.py
+++ b/libai/models/utils/graph_base.py
@@ -62,7 +62,7 @@ class GraphBase(nn.Graph):
                 self.set_activation_checkpoint()
 
             if zero_optim:
-                self.config.enable_zero(True, stage = zero_stage)
+                self.config.enable_zero(True, stage=zero_stage)
 
             self.set_pipeline_stage_id()
 

--- a/libai/models/utils/graph_base.py
+++ b/libai/models/utils/graph_base.py
@@ -62,16 +62,7 @@ class GraphBase(nn.Graph):
                 self.set_activation_checkpoint()
 
             if zero_optim:
-                dist_util = dist.get_dist_util()
-                assert (
-                    not dist_util.is_tensor_model_parallel()
-                ), "ZeRO don't support tensor_model_parallel!"
-                self.config.set_zero_redundancy_optimizer_mode("distributed_split")
-                if zero_stage > 1:
-                    flow.boxing.nccl.enable_use_compute_stream(True)
-                if zero_stage > 2:
-                    # stage 3
-                    flow.boxing.nccl.disable_group_boxing_by_dst_parallel(True)
+                self.config.enable_zero(True, stage = zero_stage)
 
             self.set_pipeline_stage_id()
 


### PR DESCRIPTION
修复zero的使用方法。


**oneflow版本**
```
loaded library: /lib/libibverbs.so.1
path: ['/home/chengpeng/anaconda3/envs/of/lib/python3.8/site-packages/oneflow']
version: 0.8.0+cu112.git.932a6936
git_commit: 932a6936
cmake_build_type: Release
rdma: True
mlir: True
```

**libai版本**
分支：[refine_zero](https://github.com/Oneflow-Inc/libai/tree/refine_zero)
commit id：432e5f26a176d1eda1004c68f926ac986c098392

用`bert_large_pretrain.py`作为测试:

### 跑单机四卡, 数据并行

- 未开启zero时, 吞吐386.66, 显存`9250MiB`
```
I20220616 09:05:12.244477 2976557 plan_util.cpp:963]  Graph name GraphBase_0 in Rank: 0, Device: 0 needs to allocate [ 8414.27 MiB ] device memory. 
 In general, Chunk id: 0  memory is [ 7367.35 MiB ]; 
 Memory out of Chunk is  [ 1046.92 MiB ]; and in particular: Eager Variable Tensor total memory is [ 1046.58 MiB ].
I20220616 09:05:12.244848 2976557 plan_util.cpp:963]  Graph name GraphBase_0 in Rank: 1, Device: 1 needs to allocate [ 8066.13 MiB ] device memory. 
 In general, Chunk id: 3  memory is [ 7019.21 MiB ]; 
 Memory out of Chunk is  [ 1046.92 MiB ]; and in particular: Eager Variable Tensor total memory is [ 1046.58 MiB ].
I20220616 09:05:12.245164 2976557 plan_util.cpp:963]  Graph name GraphBase_0 in Rank: 2, Device: 2 needs to allocate [ 8066.13 MiB ] device memory. 
 In general, Chunk id: 2  memory is [ 7019.21 MiB ]; 
 Memory out of Chunk is  [ 1046.92 MiB ]; and in particular: Eager Variable Tensor total memory is [ 1046.58 MiB ].
I20220616 09:05:12.245463 2976557 plan_util.cpp:963]  Graph name GraphBase_0 in Rank: 3, Device: 3 needs to allocate [ 8066.13 MiB ] device memory. 
 In general, Chunk id: 1  memory is [ 7019.21 MiB ]; 
 Memory out of Chunk is  [ 1046.92 MiB ]; and in particular: Eager Variable Tensor total memory is [ 1046.58 MiB ].
```


- 开启zero2后, 吞吐383.88, 显存`8878MiB`

```
I20220616 09:01:54.075668 2971555 plan_util.cpp:963]  Graph name GraphBase_0 in Rank: 0, Device: 0 needs to allocate [ 7281.85 MiB ] device memory. 
 In general, Chunk id: 0  memory is [ 7019.3 MiB ]; 
 Memory out of Chunk is  [ 262.558 MiB ]; and in particular: Eager Variable Tensor total memory is [ 262.216 MiB ].
I20220616 09:01:54.076196 2971555 plan_util.cpp:963]  Graph name GraphBase_0 in Rank: 1, Device: 1 needs to allocate [ 7281.86 MiB ] device memory. 
 In general, Chunk id: 1  memory is [ 7019.3 MiB ]; 
 Memory out of Chunk is  [ 262.56 MiB ]; and in particular: Eager Variable Tensor total memory is [ 262.216 MiB ].
I20220616 09:01:54.076661 2971555 plan_util.cpp:963]  Graph name GraphBase_0 in Rank: 2, Device: 2 needs to allocate [ 7281.86 MiB ] device memory. 
 In general, Chunk id: 3  memory is [ 7019.3 MiB ]; 
 Memory out of Chunk is  [ 262.56 MiB ]; and in particular: Eager Variable Tensor total memory is [ 262.216 MiB ].
I20220616 09:01:54.077123 2971555 plan_util.cpp:963]  Graph name GraphBase_0 in Rank: 3, Device: 3 needs to allocate [ 7281.86 MiB ] device memory. 
 In general, Chunk id: 2  memory is [ 7019.3 MiB ]; 
 Memory out of Chunk is  [ 262.56 MiB ]; and in particular: Eager Variable Tensor total memory is [ 262.216 MiB ].
```

- 按照`self.config.enable_zero(True, stage=zero_stage, shard_restore_level=2)`开启zero2后,
   吞吐379.55, 显存`8616MiB`



### 跑 dp2+mp2

- 不开zero2

吞吐206.60, 显存`6314MiB/6378MiB/6602MiB/6602MiB`
```
I20220616 09:06:52.127390 2979388 plan_util.cpp:963]  Graph name GraphBase_0 in Rank: 0, Device: 0 needs to allocate [ 4872.59 MiB ] device memory. 
 In general, Chunk id: 3  memory is [ 4346.34 MiB ]; 
 Memory out of Chunk is  [ 526.251 MiB ]; and in particular: Eager Variable Tensor total memory is [ 525.909 MiB ].
I20220616 09:06:52.127813 2979388 plan_util.cpp:963]  Graph name GraphBase_0 in Rank: 1, Device: 1 needs to allocate [ 4872.63 MiB ] device memory. 
 In general, Chunk id: 1  memory is [ 4346.38 MiB ]; 
 Memory out of Chunk is  [ 526.253 MiB ]; and in particular: Eager Variable Tensor total memory is [ 525.909 MiB ].
I20220616 09:06:52.128181 2979388 plan_util.cpp:963]  Graph name GraphBase_0 in Rank: 2, Device: 2 needs to allocate [ 4872.63 MiB ] device memory. 
 In general, Chunk id: 2  memory is [ 4346.38 MiB ]; 
 Memory out of Chunk is  [ 526.256 MiB ]; and in particular: Eager Variable Tensor total memory is [ 525.909 MiB ].
I20220616 09:06:52.128546 2979388 plan_util.cpp:963]  Graph name GraphBase_0 in Rank: 3, Device: 3 needs to allocate [ 4872.6 MiB ] device memory. 
 In general, Chunk id: 0  memory is [ 4346.34 MiB ]; 
 Memory out of Chunk is  [ 526.256 MiB ]; and in particular: Eager Variable Tensor total memory is [ 525.909 MiB ].
```

- 开启zero2

吞吐208.04, 显存`6210MiB/6298MiB/6546MiB/6522MiB`
```
I20220616 09:09:12.142958 2982748 plan_util.cpp:963]  Graph name GraphBase_0 in Rank: 0, Device: 0 needs to allocate [ 4610 MiB ] device memory. 
 In general, Chunk id: 2  memory is [ 4346.39 MiB ]; 
 Memory out of Chunk is  [ 263.618 MiB ]; and in particular: Eager Variable Tensor total memory is [ 263.276 MiB ].
I20220616 09:09:12.143443 2982748 plan_util.cpp:963]  Graph name GraphBase_0 in Rank: 1, Device: 1 needs to allocate [ 4610.04 MiB ] device memory. 
 In general, Chunk id: 3  memory is [ 4346.42 MiB ]; 
 Memory out of Chunk is  [ 263.62 MiB ]; and in particular: Eager Variable Tensor total memory is [ 263.276 MiB ].
I20220616 09:09:12.143853 2982748 plan_util.cpp:963]  Graph name GraphBase_0 in Rank: 2, Device: 2 needs to allocate [ 4610.04 MiB ] device memory. 
 In general, Chunk id: 1  memory is [ 4346.42 MiB ]; 
 Memory out of Chunk is  [ 263.622 MiB ]; and in particular: Eager Variable Tensor total memory is [ 263.276 MiB ].
I20220616 09:09:12.144285 2982748 plan_util.cpp:963]  Graph name GraphBase_0 in Rank: 3, Device: 3 needs to allocate [ 4610.04 MiB ] device memory. 
 In general, Chunk id: 0  memory is [ 4346.42 MiB ]; 
 Memory out of Chunk is  [ 263.622 MiB ]; and in particular: Eager Variable Tensor total memory is [ 263.276 MiB ].
```

### 跑 dp2+mp2 补充实验
可能是模型比较小 , 降得不明显. 
所以把`bert_large_pretrain.py`里面的`model.cfg.hidden_size = 768 * 3`扩大了三倍,
以下为实验记录

- 不开启zero, 吞吐100.42, 显存`10186MiB/10374MiB/10598MiB/10598MiB`
```
I20220616 09:28:31.945727 3019949 plan_util.cpp:963]  Graph name GraphBase_0 in Rank: 0, Device: 0 needs to allocate [ 8778.31 MiB ] device memory. 
 In general, Chunk id: 0  memory is [ 6478.96 MiB ]; 
 Memory out of Chunk is  [ 2299.35 MiB ]; and in particular: Eager Variable Tensor total memory is [ 2299.01 MiB ].
I20220616 09:28:31.946147 3019949 plan_util.cpp:963]  Graph name GraphBase_0 in Rank: 1, Device: 1 needs to allocate [ 8778.35 MiB ] device memory. 
 In general, Chunk id: 1  memory is [ 6478.99 MiB ]; 
 Memory out of Chunk is  [ 2299.36 MiB ]; and in particular: Eager Variable Tensor total memory is [ 2299.01 MiB ].
I20220616 09:28:31.946501 3019949 plan_util.cpp:963]  Graph name GraphBase_0 in Rank: 2, Device: 2 needs to allocate [ 8778.35 MiB ] device memory. 
 In general, Chunk id: 2  memory is [ 6478.99 MiB ]; 
 Memory out of Chunk is  [ 2299.36 MiB ]; and in particular: Eager Variable Tensor total memory is [ 2299.01 MiB ].
I20220616 09:28:31.946851 3019949 plan_util.cpp:963]  Graph name GraphBase_0 in Rank: 3, Device: 3 needs to allocate [ 8778.35 MiB ] device memory. 
 In general, Chunk id: 3  memory is [ 6478.99 MiB ]; 
 Memory out of Chunk is  [ 2299.36 MiB ]; and in particular: Eager Variable Tensor total memory is [ 2299.01 MiB ].
```
- 开启zero2, 吞吐102.49, 显存`9456MiB/9644MiB/9892MiB/9892MiB`
```
I20220616 09:30:42.247208 3025022 plan_util.cpp:963]  Graph name GraphBase_0 in Rank: 0, Device: 0 needs to allocate [ 7628.91 MiB ] device memory. 
 In general, Chunk id: 1  memory is [ 6479.03 MiB ]; 
 Memory out of Chunk is  [ 1149.87 MiB ]; and in particular: Eager Variable Tensor total memory is [ 1149.53 MiB ].
I20220616 09:30:42.247839 3025022 plan_util.cpp:963]  Graph name GraphBase_0 in Rank: 1, Device: 1 needs to allocate [ 7628.91 MiB ] device memory. 
 In general, Chunk id: 2  memory is [ 6479.03 MiB ]; 
 Memory out of Chunk is  [ 1149.87 MiB ]; and in particular: Eager Variable Tensor total memory is [ 1149.53 MiB ].
I20220616 09:30:42.248414 3025022 plan_util.cpp:963]  Graph name GraphBase_0 in Rank: 2, Device: 2 needs to allocate [ 7628.88 MiB ] device memory. 
 In general, Chunk id: 3  memory is [ 6479 MiB ]; 
 Memory out of Chunk is  [ 1149.88 MiB ]; and in particular: Eager Variable Tensor total memory is [ 1149.53 MiB ].
I20220616 09:30:42.248955 3025022 plan_util.cpp:963]  Graph name GraphBase_0 in Rank: 3, Device: 3 needs to allocate [ 7628.91 MiB ] device memory. 
 In general, Chunk id: 0  memory is [ 6479.03 MiB ]; 
 Memory out of Chunk is  [ 1149.88 MiB ]; and in particular: Eager Variable Tensor total memory is [ 1149.53 MiB ].
```