### PR TITLE
add WarmupStepLR

### DIFF
--- a/libai/scheduler/__init__.py
+++ b/libai/scheduler/__init__.py
@@ -20,4 +20,5 @@ from .lr_scheduler import (
     WarmupExponentialLR,
     WarmupMultiStepLR,
     WarmupPolynomialLR,
+    WarmupStepLR,
 )

--- a/libai/scheduler/lr_scheduler.py
+++ b/libai/scheduler/lr_scheduler.py
@@ -123,6 +123,8 @@ def WarmupStepLR(
             In linear mode, the multiplication factor starts with warmup_factor in the first
             epoch and then inreases linearly to reach 1. Defaults to "linear".
     """
+    # Since LiBai executes scheduler.step() per iter,
+    # the step_size is converted to the iter-style version.
     step_size = (step_size / train_epoch) * max_iter
     step_lr = flow.optim.lr_scheduler.StepLR(
         optimizer, step_size=step_size, gamma=gamma

--- a/libai/scheduler/lr_scheduler.py
+++ b/libai/scheduler/lr_scheduler.py
@@ -239,7 +239,11 @@ def WarmupPolynomialLR(
             epoch and then inreases linearly to reach 1. Defaults to "linear".
     """
     polynomial_lr = flow.optim.lr_scheduler.PolynomialLR(
-        optimizer, decay_batch=max_iter, end_learning_rate=end_learning_rate, power=power, cycle=cycle
+        optimizer,
+        decay_batch=max_iter,
+        end_learning_rate=end_learning_rate,
+        power=power,
+        cycle=cycle,
     )
     if warmup_iter == 0:
         logger.warning("warmup iters equals to zero, return PolynomialLR")

--- a/libai/scheduler/lr_scheduler.py
+++ b/libai/scheduler/lr_scheduler.py
@@ -121,9 +121,7 @@ def WarmupStepLR(
             In linear mode, the multiplication factor starts with warmup_factor in the first
             epoch and then inreases linearly to reach 1. Defaults to "linear".
     """
-    step_lr = flow.optim.lr_scheduler.StepLR(
-        optimizer, step_size=step_size, gamma=gamma
-    )
+    step_lr = flow.optim.lr_scheduler.StepLR(optimizer, step_size=step_size, gamma=gamma)
     if warmup_iter == 0:
         logger.warning("warmup iters equals to zero, return StepLR")
         return step_lr
@@ -133,7 +131,7 @@ def WarmupStepLR(
         warmup_iters=warmup_iter,
         warmup_method=warmup_method,
     )
-    return warmup_step_lr 
+    return warmup_step_lr
 
 
 def WarmupMultiStepLR(

--- a/libai/scheduler/lr_scheduler.py
+++ b/libai/scheduler/lr_scheduler.py
@@ -101,7 +101,6 @@ def WarmupCosineAnnealingLR(
 def WarmupStepLR(
     optimizer: flow.optim.Optimizer,
     max_iter: int,
-    train_epoch: int,
     warmup_factor: float,
     warmup_iter: int,
     step_size: int,
@@ -114,7 +113,6 @@ def WarmupStepLR(
     Args:
         optimizer (flow.optim.Optimizer): Wrapped optimizer.
         max_iter (int): Total training iters.
-        train_epoch (int): Total training epochs.
         warmup_factor (float): The warmup factor.
         warmup_iter (int): The number of warmup steps.
         step_size (int): Period of learning rate decay.
@@ -123,9 +121,6 @@ def WarmupStepLR(
             In linear mode, the multiplication factor starts with warmup_factor in the first
             epoch and then inreases linearly to reach 1. Defaults to "linear".
     """
-    # Since LiBai executes scheduler.step() per iter,
-    # the step_size is converted to the iter-style version.
-    step_size = (step_size / train_epoch) * max_iter
     step_lr = flow.optim.lr_scheduler.StepLR(
         optimizer, step_size=step_size, gamma=gamma
     )

--- a/libai/scheduler/lr_scheduler.py
+++ b/libai/scheduler/lr_scheduler.py
@@ -239,7 +239,7 @@ def WarmupPolynomialLR(
             epoch and then inreases linearly to reach 1. Defaults to "linear".
     """
     polynomial_lr = flow.optim.lr_scheduler.PolynomialLR(
-        optimizer, steps=max_iter, end_learning_rate=end_learning_rate, power=power, cycle=cycle
+        optimizer, decay_batch=max_iter, end_learning_rate=end_learning_rate, power=power, cycle=cycle
     )
     if warmup_iter == 0:
         logger.warning("warmup iters equals to zero, return PolynomialLR")

--- a/libai/scheduler/lr_scheduler.py
+++ b/libai/scheduler/lr_scheduler.py
@@ -101,6 +101,7 @@ def WarmupCosineAnnealingLR(
 def WarmupStepLR(
     optimizer: flow.optim.Optimizer,
     max_iter: int,
+    train_epoch: int,
     warmup_factor: float,
     warmup_iter: int,
     step_size: int,
@@ -113,6 +114,7 @@ def WarmupStepLR(
     Args:
         optimizer (flow.optim.Optimizer): Wrapped optimizer.
         max_iter (int): Total training iters.
+        train_epoch (int): Total training epochs.
         warmup_factor (float): The warmup factor.
         warmup_iter (int): The number of warmup steps.
         step_size (int): Period of learning rate decay.
@@ -121,6 +123,7 @@ def WarmupStepLR(
             In linear mode, the multiplication factor starts with warmup_factor in the first
             epoch and then inreases linearly to reach 1. Defaults to "linear".
     """
+    step_size = (step_size / train_epoch) * max_iter
     step_lr = flow.optim.lr_scheduler.StepLR(
         optimizer, step_size=step_size, gamma=gamma
     )

--- a/libai/scheduler/lr_scheduler.py
+++ b/libai/scheduler/lr_scheduler.py
@@ -98,6 +98,44 @@ def WarmupCosineAnnealingLR(
     return warmup_cosine_annealing_lr
 
 
+def WarmupStepLR(
+    optimizer: flow.optim.Optimizer,
+    max_iter: int,
+    warmup_factor: float,
+    warmup_iter: int,
+    step_size: int,
+    gamma: float = 0.1,
+    warmup_method: str = "linear",
+):
+    """Create a schedule with a learning rate that decreases following the values of the Step
+    function between the initial lr set in the optimizer to 0, after a warmup period during which
+    it increases linearly between 0 and the initial lr set in the optimizer.
+    Args:
+        optimizer (flow.optim.Optimizer): Wrapped optimizer.
+        max_iter (int): Total training iters.
+        warmup_factor (float): The warmup factor.
+        warmup_iter (int): The number of warmup steps.
+        step_size (int): Period of learning rate decay.
+        gamma (float, optional): Multiplicative factor of learning rate decay. Defaults to 0.1.
+        warmup_method (str, optional): The method of warmup, you can choose "linear" or "constant".
+            In linear mode, the multiplication factor starts with warmup_factor in the first
+            epoch and then inreases linearly to reach 1. Defaults to "linear".
+    """
+    step_lr = flow.optim.lr_scheduler.StepLR(
+        optimizer, step_size==step_size, gamma=gamma
+    )
+    if warmup_iter == 0:
+        logger.warning("warmup iters equals to zero, return StepLR")
+        return step_lr
+    warmup_step_lr = flow.optim.lr_scheduler.WarmUpLR(
+        step_lr,
+        warmup_factor=warmup_factor,
+        warmup_iters=warmup_iter,
+        warmup_method=warmup_method,
+    )
+    return warmup_step_lr 
+
+
 def WarmupMultiStepLR(
     optimizer: flow.optim.Optimizer,
     max_iter: int,

--- a/libai/scheduler/lr_scheduler.py
+++ b/libai/scheduler/lr_scheduler.py
@@ -122,7 +122,7 @@ def WarmupStepLR(
             epoch and then inreases linearly to reach 1. Defaults to "linear".
     """
     step_lr = flow.optim.lr_scheduler.StepLR(
-        optimizer, step_size==step_size, gamma=gamma
+        optimizer, step_size=step_size, gamma=gamma
     )
     if warmup_iter == 0:
         logger.warning("warmup iters equals to zero, return StepLR")

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -133,14 +133,18 @@ class TestScheduler(TestCase):
 
         def _get_exponential_lr(base_lr, gamma, max_iters, warmup_iters):
             valid_values = []
-            for idx in range(warmup_iters, max_iters+1):
+            for idx in range(warmup_iters, max_iters + 1):
                 valid_values.append(base_lr * (gamma ** idx))
             return valid_values
 
         for _ in range(30):
             sched.step()
             lrs.append(opt.param_groups[0]["lr"])
-        self.assertTrue(np.allclose(lrs[:5], [0.005, 0.00401, 0.0030199999999999997, 0.00203, 0.0010399999999999997]))
+        self.assertTrue(
+            np.allclose(
+                lrs[:5], [0.005, 0.00401, 0.0030199999999999997, 0.00203, 0.0010399999999999997]
+            )
+        )
         valid_intermediate_values = _get_exponential_lr(
             base_lr=5.0, gamma=0.1, max_iters=30, warmup_iters=5
         )

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -30,7 +30,7 @@ from libai.scheduler import (
 )
 
 
-@unittest.skip("Bugs in warmup scheduler")
+# @unittest.skip("Bugs in warmup scheduler")
 class TestScheduler(TestCase):
     def test_warmup_multistep(self):
         p = nn.Parameter(flow.zeros(0))
@@ -133,18 +133,18 @@ class TestScheduler(TestCase):
 
         def _get_exponential_lr(base_lr, gamma, max_iters, warmup_iters):
             valid_values = []
-            for idx in range(max_iters - warmup_iters):
+            for idx in range(warmup_iters, max_iters+1):
                 valid_values.append(base_lr * (gamma ** idx))
             return valid_values
 
         for _ in range(30):
             sched.step()
             lrs.append(opt.param_groups[0]["lr"])
-        self.assertTrue(np.allclose(lrs[:5], [0.005, 1.004, 2.003, 3.002, 4.001]))
+        self.assertTrue(np.allclose(lrs[:5], [0.005, 0.00401, 0.0030199999999999997, 0.00203, 0.0010399999999999997]))
         valid_intermediate_values = _get_exponential_lr(
             base_lr=5.0, gamma=0.1, max_iters=30, warmup_iters=5
         )
-        self.assertEqual(lrs[5:30], valid_intermediate_values)
+        self.assertEqual(lrs[5:], valid_intermediate_values)
 
     def test_warmup_polynomial(self):
         p = nn.Parameter(flow.zeros(0))


### PR DESCRIPTION
该pr为LiBai添加WarmupStepLR支持，以及修复test_warmup_exponential测试代码error

- [x] WarmupStepLR代码
- [x] unittest代码
- [x] 测试(在vit上做了一些iter的训练，WarmupStepLR学习率衰减正常)
- [x] 修复test_warmup_exponential测试代码error

`Auto-scaling the config to train.train_iter=100, train.warmup_iter=2 step_size=10`

```
[06/27 08:45:41 lb.engine.trainer]: Starting training from iteration 0
[06/27 08:45:43 lb.utils.events]:  iteration: 0/100  consumed_samples: 16  total_loss: 2.344  data_time: 0.2230 s/iter  lr: 0.00e+00  
[06/27 08:45:43 lb.utils.events]:  eta: 0:00:42  iteration: 1/100  consumed_samples: 32  total_loss: 2.373  data_time: 0.2223 s/iter  lr: 5.00e-04  
[06/27 08:45:44 lb.utils.events]:  eta: 0:00:26  iteration: 2/100  consumed_samples: 48  total_loss: 2.401  time: 0.2740 s/iter  data_time: 0.2175 s/iter total_throughput: 58.38 samples/s lr: 1.00e-03  
[06/27 08:45:44 lb.utils.events]:  eta: 0:00:26  iteration: 3/100  consumed_samples: 64  total_loss: 2.706  time: 0.2739 s/iter  data_time: 0.2169 s/iter total_throughput: 58.41 samples/s lr: 1.00e-03  
[06/27 08:45:44 lb.utils.events]:  eta: 0:00:26  iteration: 4/100  consumed_samples: 80  total_loss: 2.693  time: 0.2773 s/iter  data_time: 0.2180 s/iter total_throughput: 57.70 samples/s lr: 1.00e-03  
[06/27 08:45:44 lb.utils.events]:  eta: 0:00:26  iteration: 5/100  consumed_samples: 96  total_loss: 2.648  time: 0.2784 s/iter  data_time: 0.2162 s/iter total_throughput: 57.47 samples/s lr: 1.00e-03  
[06/27 08:45:45 lb.utils.events]:  eta: 0:00:26  iteration: 6/100  consumed_samples: 112  total_loss: 2.602  time: 0.2788 s/iter  data_time: 0.2170 s/iter total_throughput: 57.39 samples/s lr: 1.00e-03  
[06/27 08:45:45 lb.utils.events]:  eta: 0:00:25  iteration: 7/100  consumed_samples: 128  total_loss: 2.57  time: 0.2788 s/iter  data_time: 0.2174 s/iter total_throughput: 57.38 samples/s lr: 1.00e-03  
[06/27 08:45:45 lb.utils.events]:  eta: 0:00:25  iteration: 8/100  consumed_samples: 144  total_loss: 2.538  time: 0.2749 s/iter  data_time: 0.2142 s/iter total_throughput: 58.21 samples/s lr: 1.00e-03  
[06/27 08:45:46 lb.evaluation.evaluator]: with eval_iter 10, reset total samples 10000 to 2560
[06/27 08:45:46 lb.evaluation.evaluator]: Start inference on 2560 samples
[06/27 08:46:02 lb.evaluation.evaluator]: Total valid samples: 2560
[06/27 08:46:02 lb.evaluation.evaluator]: Total inference time: 0:00:07.512320 (0.002940 s / iter per device, on 4 devices)
[06/27 08:46:02 lb.evaluation.evaluator]: Total inference pure compute time: 0:00:01 (0.000398 s / iter per device, on 4 devices)
[06/27 08:46:02 lb.engine.default]: Evaluation results for CIFAR10Dataset in csv format:
[06/27 08:46:02 lb.evaluation.utils]: copypaste: Acc@1=14.6875
[06/27 08:46:02 lb.evaluation.utils]: copypaste: Acc@5=49.84375
[06/27 08:46:02 lb.engine.hooks]: Saved first model at 14.68750 @ 9 steps
[06/27 08:46:03 lb.utils.checkpoint]: Saving checkpoint to output_unittest/test_vit/model_best
[06/27 08:46:09 lb.utils.events]:  eta: 0:00:25  iteration: 9/100  consumed_samples: 160  total_loss: 2.536  time: 0.2766 s/iter  data_time: 0.2146 s/iter total_throughput: 57.84 samples/s lr: 1.00e-03  
[06/27 08:46:09 lb.utils.events]:  eta: 0:00:24  iteration: 10/100  consumed_samples: 176  total_loss: 2.534  time: 0.2692 s/iter  data_time: 0.2082 s/iter total_throughput: 59.43 samples/s lr: 1.00e-04  
[06/27 08:46:10 lb.utils.events]:  eta: 0:00:24  iteration: 11/100  consumed_samples: 192  total_loss: 2.467  time: 0.2686 s/iter  data_time: 0.2083 s/iter total_throughput: 59.57 samples/s lr: 1.00e-04  
[06/27 08:46:10 lb.utils.events]:  eta: 0:00:24  iteration: 12/100  consumed_samples: 208  total_loss: 2.428  time: 0.2693 s/iter  data_time: 0.2085 s/iter total_throughput: 59.42 samples/s lr: 1.00e-04  
[06/27 08:46:10 lb.utils.events]:  eta: 0:00:23  iteration: 13/100  consumed_samples: 224  total_loss: 2.414  time: 0.2665 s/iter  data_time: 0.2071 s/iter total_throughput: 60.03 samples/s lr: 1.00e-04  
[06/27 08:46:10 lb.utils.events]:  eta: 0:00:23  iteration: 14/100  consumed_samples: 240  total_loss: 2.428  time: 0.2654 s/iter  data_time: 0.2069 s/iter total_throughput: 60.28 samples/s lr: 1.00e-04  
[06/27 08:46:11 lb.utils.events]:  eta: 0:00:23  iteration: 15/100  consumed_samples: 256  total_loss: 2.414  time: 0.2641 s/iter  data_time: 0.2061 s/iter total_throughput: 60.59 samples/s lr: 1.00e-04  
[06/27 08:46:11 lb.utils.events]:  eta: 0:00:22  iteration: 16/100  consumed_samples: 272  total_loss: 2.401  time: 0.2621 s/iter  data_time: 0.2048 s/iter total_throughput: 61.05 samples/s lr: 1.00e-04  
[06/27 08:46:11 lb.utils.events]:  eta: 0:00:22  iteration: 17/100  consumed_samples: 288  total_loss: 2.389  time: 0.2597 s/iter  data_time: 0.2030 s/iter total_throughput: 61.62 samples/s lr: 1.00e-04  
[06/27 08:46:11 lb.utils.events]:  eta: 0:00:21  iteration: 18/100  consumed_samples: 304  total_loss: 2.378  time: 0.2581 s/iter  data_time: 0.2020 s/iter total_throughput: 62.00 samples/s lr: 1.00e-04  
[06/27 08:46:12 lb.evaluation.evaluator]: with eval_iter 10, reset total samples 10000 to 2560
[06/27 08:46:12 lb.evaluation.evaluator]: Start inference on 2560 samples
[06/27 08:46:28 lb.evaluation.evaluator]: Total valid samples: 2560
[06/27 08:46:28 lb.evaluation.evaluator]: Total inference time: 0:00:07.433129 (0.002909 s / iter per device, on 4 devices)
[06/27 08:46:28 lb.evaluation.evaluator]: Total inference pure compute time: 0:00:00 (0.000322 s / iter per device, on 4 devices)
[06/27 08:46:28 lb.engine.default]: Evaluation results for CIFAR10Dataset in csv format:
[06/27 08:46:28 lb.evaluation.utils]: copypaste: Acc@1=14.4921875
[06/27 08:46:28 lb.evaluation.utils]: copypaste: Acc@5=48.515625
[06/27 08:46:28 lb.engine.hooks]: Not saving as latest eval score for Acc@1 is 14.49219, not better than best score 14.68750 @ iteration 9.
[06/27 08:46:28 lb.utils.events]:  eta: 0:00:20  iteration: 19/100  consumed_samples: 320  total_loss: 2.37  time: 0.2574 s/iter  data_time: 0.2016 s/iter total_throughput: 62.16 samples/s lr: 1.00e-04  
[06/27 08:46:29 lb.utils.events]:  eta: 0:00:19  iteration: 20/100  consumed_samples: 336  total_loss: 2.362  time: 0.2561 s/iter  data_time: 0.1996 s/iter total_throughput: 62.48 samples/s lr: 1.00e-05  
[06/27 08:46:29 lb.utils.events]:  eta: 0:00:19  iteration: 21/100  consumed_samples: 352  total_loss: 2.37  time: 0.2556 s/iter  data_time: 0.1984 s/iter total_throughput: 62.59 samples/s lr: 1.00e-05  
[06/27 08:46:29 lb.utils.events]:  eta: 0:00:19  iteration: 22/100  consumed_samples: 368  total_loss: 2.362  time: 0.2548 s/iter  data_time: 0.1975 s/iter total_throughput: 62.79 samples/s lr: 1.00e-05  
[06/27 08:46:29 lb.utils.events]:  eta: 0:00:18  iteration: 23/100  consumed_samples: 384  total_loss: 2.362  time: 0.2542 s/iter  data_time: 0.1964 s/iter total_throughput: 62.95 samples/s lr: 1.00e-05  
[06/27 08:46:30 lb.utils.events]:  eta: 0:00:18  iteration: 24/100  consumed_samples: 400  total_loss: 2.362  time: 0.2542 s/iter  data_time: 0.1955 s/iter total_throughput: 62.95 samples/s lr: 1.00e-05  
[06/27 08:46:30 lb.utils.events]:  eta: 0:00:18  iteration: 25/100  consumed_samples: 416  total_loss: 2.364  time: 0.2546 s/iter  data_time: 0.1956 s/iter total_throughput: 62.84 samples/s lr: 1.00e-05  
[06/27 08:46:30 lb.utils.events]:  eta: 0:00:18  iteration: 26/100  consumed_samples: 432  total_loss: 2.362  time: 0.2542 s/iter  data_time: 0.1944 s/iter total_throughput: 62.93 samples/s lr: 1.00e-05  
[06/27 08:46:30 lb.utils.events]:  eta: 0:00:17  iteration: 27/100  consumed_samples: 448  total_loss: 2.362  time: 0.2538 s/iter  data_time: 0.1930 s/iter total_throughput: 63.04 samples/s lr: 1.00e-05  
[06/27 08:46:31 lb.utils.events]:  eta: 0:00:17  iteration: 28/100  consumed_samples: 464  total_loss: 2.362  time: 0.2537 s/iter  data_time: 0.1935 s/iter total_throughput: 63.08 samples/s lr: 1.00e-05 
```