### PR TITLE
add pipeline stage id

### DIFF
--- a/configs/common/train.py
+++ b/configs/common/train.py
@@ -115,26 +115,28 @@ train = dict(
         data_parallel_size=1,
         tensor_parallel_size=1,
         pipeline_parallel_size=1,
-        # set pipeline_num_layers when pipeline_parallel_size > 1
+        # users must set the `pipeline_num_layers` attribute when `pipeline_parallel_size > 1`
         pipeline_num_layers=None,
-        # custom_pipeline_stage_id could be set for adjust num_layers in different stages
-        # it is usually used for manually balance calculation between stages in pipeline_parallelism
+        # users could customize the number of layers in different stages
+        # by setting the `custom_pipeline_stage_id ` attribute which is used for
+        # manually balance calculation between stages when running pipeline parallelism
         # e.g. you can set `custom_pipeline_stage_id=[0, 0, 0, 1]`
         # for `pipeline_num_layers=4 and pipeline_parallel_size=2`
-        # it means the first 3 layers will be located in stage0 and
-        # the last layer will located in stage1
+        # which means the first 3 layers will be placed on stage0 and
+        # the last layer will be placed on stage1
         # NOTE: if it is None, LiBai will automatically set pipeline_stage_id
         # `auto_pipeline_stage_id` and `actual_pipeline_stage_id` will be saved in `config.yaml`
         custom_pipeline_stage_id=None,
     ),
 
-    # device type of input tensor in model, in most cases set it to "cuda".
-    # when pipeline_parallel > 1 and you want to ultimate acceleration in model training
-    # set `input_placement_device="cpu"` and use tensor.to_global() in your model.forward()
+    # the device type of input tensors for model, defaults to "cuda".
+    # if you want to accelerate the model training when pipeline_parallel > 1
+    # you can set `input_placement_device="cpu"` then call input_tensor.to_global()
+    # inside your model.forward() method
     # see `libai/models/bert_model.py` as reference
     input_placement_device="cuda",
 
-    # rdma enabled, set it to `True` for improving speed of pipeline_parallel
+    # set to `True` to enable rdma for improving speed of pipeline_parallel
     rdma_enabled=True,
 
     # Set seed to positive to use a fixed seed. Note that a fixed seed increases

--- a/configs/common/train.py
+++ b/configs/common/train.py
@@ -115,6 +115,17 @@ train = dict(
         data_parallel_size=1,
         tensor_parallel_size=1,
         pipeline_parallel_size=1,
+        # set pipeline_num_layers when pipeline_parallel_size > 1
+        pipeline_num_layers=None,
+        # custom_pipeline_stage_id could be set for adjust num_layers in different stages
+        # it is usually used for manually balance calculation between stages in pipeline_parallelism
+        # e.g. you can set `custom_pipeline_stage_id=[0, 0, 0, 1]`
+        # for `pipeline_num_layers=4 and pipeline_parallel_size=2`
+        # it means the first 3 layers will be located in stage0 and
+        # the last layer will located in stage1
+        # NOTE: if it is None, LiBai will automatically set pipeline_stage_id
+        # `auto_pipeline_stage_id` and `actual_pipeline_stage_id` will be saved in `config.yaml`
+        custom_pipeline_stage_id=None,
     ),
 
     # device type of input tensor in model, in most cases set it to "cuda".

--- a/docs/source/tutorials/basics/Config_System.md
+++ b/docs/source/tutorials/basics/Config_System.md
@@ -190,26 +190,28 @@ train = dict(
         data_parallel_size=1,
         tensor_parallel_size=1,
         pipeline_parallel_size=1,
-        # set pipeline_num_layers when pipeline_parallel_size > 1
+        # users must set the `pipeline_num_layers` attribute when `pipeline_parallel_size > 1`
         pipeline_num_layers=None,
-        # custom_pipeline_stage_id could be set for adjust num_layers in different stages
-        # it is usually used for manually balance calculation between stages in pipeline_parallelism
-        # e.g. you can set `custom_pipeline_stage_id=[0, 0, 0, 1]` 
+        # users could customize the number of layers in different stages
+        # by setting the `custom_pipeline_stage_id ` attribute which is used for
+        # manually balance calculation between stages when running pipeline parallelism
+        # e.g. you can set `custom_pipeline_stage_id=[0, 0, 0, 1]`
         # for `pipeline_num_layers=4 and pipeline_parallel_size=2`
-        # it means the first 3 layers will be located in stage0 and 
-        # the last layer will located in stage1
+        # which means the first 3 layers will be placed on stage0 and
+        # the last layer will be placed on stage1
         # NOTE: if it is None, LiBai will automatically set pipeline_stage_id
         # `auto_pipeline_stage_id` and `actual_pipeline_stage_id` will be saved in `config.yaml`
         custom_pipeline_stage_id=None,
     ),
 
-    # device type of input tensor in model, in most cases set it to "cuda".
-    # when pipeline_parallel > 1 and you want to ultimate acceleration in model training
-    # set `input_placement_device="cpu"` and use tensor.to_global() in your model.forward()
+    # the device type of input tensors for model, defaults to "cuda".
+    # if you want to accelerate the model training when pipeline_parallel > 1
+    # you can set `input_placement_device="cpu"` then call input_tensor.to_global()
+    # inside your model.forward() method
     # see `libai/models/bert_model.py` as reference
     input_placement_device="cuda",
 
-    # rdma enabled, set it to `True` for improving speed of pipeline_parallel
+    # set to `True` to enable rdma for improving speed of pipeline_parallel
     rdma_enabled=True,
     
     # Set seed to positive to use a fixed seed. Note that a fixed seed increases

--- a/docs/source/tutorials/basics/Config_System.md
+++ b/docs/source/tutorials/basics/Config_System.md
@@ -190,7 +190,27 @@ train = dict(
         data_parallel_size=1,
         tensor_parallel_size=1,
         pipeline_parallel_size=1,
+        # set pipeline_num_layers when pipeline_parallel_size > 1
+        pipeline_num_layers=None,
+        # custom_pipeline_stage_id could be set for adjust num_layers in different stages
+        # it is usually used for manually balance calculation between stages in pipeline_parallelism
+        # e.g. you can set `custom_pipeline_stage_id=[0, 0, 0, 1]` 
+        # for `pipeline_num_layers=4 and pipeline_parallel_size=2`
+        # it means the first 3 layers will be located in stage0 and 
+        # the last layer will located in stage1
+        # NOTE: if it is None, LiBai will automatically set pipeline_stage_id
+        # `auto_pipeline_stage_id` and `actual_pipeline_stage_id` will be saved in `config.yaml`
+        custom_pipeline_stage_id=None,
     ),
+
+    # device type of input tensor in model, in most cases set it to "cuda".
+    # when pipeline_parallel > 1 and you want to ultimate acceleration in model training
+    # set `input_placement_device="cpu"` and use tensor.to_global() in your model.forward()
+    # see `libai/models/bert_model.py` as reference
+    input_placement_device="cuda",
+
+    # rdma enabled, set it to `True` for improving speed of pipeline_parallel
+    rdma_enabled=True,
     
     # Set seed to positive to use a fixed seed. Note that a fixed seed increases
     # reproducibility but does not guarantee fully deterministic behavior.

--- a/docs/source/tutorials/basics/Distributed_Configuration.md
+++ b/docs/source/tutorials/basics/Distributed_Configuration.md
@@ -8,15 +8,15 @@ dist=dict(
         tensor_parallel_size=1,
         pipeline_parallel_size=1,
 
-
-        # set pipeline_num_layers when pipeline_parallel_size > 1
+        # users must set the `pipeline_num_layers` attribute when `pipeline_parallel_size > 1`
         pipeline_num_layers=None,
-        # custom_pipeline_stage_id could be set for adjust num_layers in different stages
-        # it is usually used for manually balance calculation between stages in pipeline_parallelism
-        # e.g. you can set `custom_pipeline_stage_id=[0, 0, 0, 1]` 
+        # users could customize the number of layers in different stages
+        # by setting the `custom_pipeline_stage_id ` attribute which is used for
+        # manually balance calculation between stages when running pipeline parallelism
+        # e.g. you can set `custom_pipeline_stage_id=[0, 0, 0, 1]`
         # for `pipeline_num_layers=4 and pipeline_parallel_size=2`
-        # it means the first 3 layers will be located in stage0 and 
-        # the last layer will located in stage1
+        # which means the first 3 layers will be placed on stage0 and
+        # the last layer will be placed on stage1
         # NOTE: if it is None, LiBai will automatically set pipeline_stage_id
         # `auto_pipeline_stage_id` and `actual_pipeline_stage_id` will be saved in `config.yaml`
         custom_pipeline_stage_id=None,
@@ -138,9 +138,9 @@ And the `data_parallel_size` will be automatically set to `(8 / (2 * 2)) = 2`
 
 
 #### **Set `custom_pipeline_stage_id` for Load Balance**
-In most cases, transformer layers have the same calculation, there is no need to set `custom_pipeline_stage_id`.
+In most cases, the transformer layers of common models have the same computational overhead, so there is no need to set `custom_pipeline_stage_id`.
 
-But when transformer layers have unbalanced calculation, you can set `custom_pipeline_stage_id` for  manually balance calculation between stages in pipeline_parallelism
+But when transformer layers have unbalanced computational overhead, you can set `custom_pipeline_stage_id` for manually balance the compuation between stages in pipeline_parallelism
 
 For example:
 ```python

--- a/libai/utils/distributed.py
+++ b/libai/utils/distributed.py
@@ -17,6 +17,7 @@ import logging
 
 import numpy as np
 import oneflow as flow
+from omegaconf import OmegaConf
 
 from libai.config import try_get_key
 
@@ -95,6 +96,22 @@ class _DistributeUtil(object):
                 f"number of layers ({cfg.pipeline_num_layers}) is less than"
                 f" pipeline model parallel size ({self._pipeline_parallel_size})"
             )
+            if try_get_key(cfg, "custom_pipeline_stage_id") is not None:
+                assert OmegaConf.is_list(
+                    cfg.custom_pipeline_stage_id
+                ), "type of cfg.train.dist.custom_pipeline_stage_id must be list"
+                cfg.custom_pipeline_stage_id = list(cfg.custom_pipeline_stage_id)
+                assert max(cfg.custom_pipeline_stage_id) <= self._world_size, (
+                    f"the element {max(cfg.custom_pipeline_stage_id)} in"
+                    " cfg.train.dist.custom_pipeline_stage_id is out of range"
+                    f" for total rank {self._world_size}"
+                )
+                assert len(cfg.custom_pipeline_stage_id) == cfg.pipeline_num_layers, (
+                    "the length of cfg.train.dist.custom_pipeline_stage_id"
+                    f" {len(cfg.custom_pipeline_stage_id)} must be equal to"
+                    " cfg.train.dist.pipeline_num_layers"
+                    f" {cfg.train.dist.pipeline_num_layers}"
+                )
         else:
             # no pipeline parallel, just set 10000
             if try_get_key(cfg, "pipeline_num_layers") is None:
@@ -132,22 +149,32 @@ class _DistributeUtil(object):
             and cfg.pipeline_num_layers % self._pipeline_parallel_size == 0
         ):
             temp_num_layers_per_stage = cfg.pipeline_num_layers // self._pipeline_parallel_size
-            cfg.pipeline_num_layers += min(
+            actual_pipeline_num_layers = cfg.pipeline_num_layers + min(
                 self._pipeline_parallel_size - 1, temp_num_layers_per_stage
             )
+        else:
+            actual_pipeline_num_layers = cfg.pipeline_num_layers
 
-        num_layers_per_stage = cfg.pipeline_num_layers // self._pipeline_parallel_size
-        stage_offset = cfg.pipeline_num_layers % self._pipeline_parallel_size
+        num_layers_per_stage = actual_pipeline_num_layers // self._pipeline_parallel_size
+        stage_offset = actual_pipeline_num_layers % self._pipeline_parallel_size
 
         # stage_offset can make the later stages contain more layers when pipeline_num_layers
         # cannot be divided by pipeline_parallel_size.
         # This can make pipeline parallel more memory efficient.
         self._layer_stage_ids = []
-        for i in range(0, cfg.pipeline_num_layers - stage_offset, num_layers_per_stage):
+        for i in range(0, actual_pipeline_num_layers - stage_offset, num_layers_per_stage):
             stage_id = i // num_layers_per_stage
             if stage_id >= (self._pipeline_parallel_size - stage_offset):
                 self._layer_stage_ids.append(stage_id)
             self._layer_stage_ids.extend([stage_id] * num_layers_per_stage)
+        self._layer_stage_ids = self._layer_stage_ids[: cfg.pipeline_num_layers]
+        # when pipeline_parallel_size > 1, we add pipeline_stage_id infomation into cfg
+        if cfg.pipeline_parallel_size > 1:
+            cfg.auto_pipeline_stage_id = self._layer_stage_ids
+            # set pipeline_stage_id by users' setting
+            if try_get_key(cfg, "custom_pipeline_stage_id") is not None:
+                self._layer_stage_ids = cfg.custom_pipeline_stage_id
+            cfg.actual_pipeline_stage_id = self._layer_stage_ids
 
         self._layer_ranks = [stages_devices[stage_id] for stage_id in self._layer_stage_ids]
 

--- a/libai/utils/distributed.py
+++ b/libai/utils/distributed.py
@@ -101,7 +101,7 @@ class _DistributeUtil(object):
                     cfg.custom_pipeline_stage_id
                 ), "type of cfg.train.dist.custom_pipeline_stage_id must be list"
                 cfg.custom_pipeline_stage_id = list(cfg.custom_pipeline_stage_id)
-                assert max(cfg.custom_pipeline_stage_id) <= self._world_size, (
+                assert max(cfg.custom_pipeline_stage_id) < self._world_size, (
                     f"the element {max(cfg.custom_pipeline_stage_id)} in"
                     " cfg.train.dist.custom_pipeline_stage_id is out of range"
                     f" for total rank {self._world_size}"


### PR DESCRIPTION
由于在pipeline并行时, 有可能会出现不同stage之间负载不均衡的问题, 会对吞吐和显存造成一定的影响.

所以支持了用户自己手动设置stage_id.

这个pr要做的:
- [x] 支持用户手动设置`pipeline_stage_id`, 默认libai会自动分配`stage_id`
- [x] 添加相关的说明
- [x] 跑通功能试验, 在`config.yaml`里面会保存额外的信息. 用户自己的`stage_id`配置, libai自动的`stage_id`配置, 以及最后使用的`stage_id`配置

![image](https://user-images.githubusercontent.com/13843079/179192065-9b677b17-35cb-41e5-80cd-f908c800ee2c.png)


