### PR TITLE
Fix to global

### DIFF
--- a/docs/source/tutorials/get_started/Installation.md
+++ b/docs/source/tutorials/get_started/Installation.md
@@ -1,4 +1,5 @@
 # Installation
+
 LiBai provides an editable installation way for you to develop your own project based on LiBai's framework.
 
 ## Build LiBai from Source
@@ -9,14 +10,57 @@ LiBai provides an editable installation way for you to develop your own project 
 git clone https://github.com/Oneflow-Inc/libai.git
 cd libai
 ```
+
 - Create a conda virtual environment and activate it:
 
 ```bash
-conda create -n libai python=3.7 -y
+conda create -n libai python=3.8 -y
 conda activate libai
 ```
 
-- Install the stable release of OneFlow with `CUDA` support. See [OneFlow installation guide](https://github.com/Oneflow-Inc/oneflow#install-with-pip-package).
+- Install the stable release of OneFlow with `CUDA` support. See [OneFlow installation guide](https://github.com/Oneflow-Inc/oneflow#install-with-pip-package). To use **latest** LiBai(branch `main`), we highly recommend you install **Nightly** Oneflow
+
+  - Stable
+
+    ```bash
+    python3 -m pip install --find-links https://release.oneflow.info oneflow==0.8.0+[PLATFORM]
+    ```
+
+  - Nightly
+
+    ```
+    python3 -m pip install --pre oneflow -f https://staging.oneflow.info/branch/master/[PLATFORM]
+    ```
+
+  - All available `[PLATFORM]`:
+  
+    <table class="docutils">
+    <thead>
+    <tr class="header">
+    <th>Platform</th>
+    <th>CUDA Driver Version</th>
+    <th>Supported GPUs</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr class="odd">
+    <td>cu112</td>
+    <td>&gt;= 450.80.02</td>
+    <td>GTX 10xx, RTX 20xx, A100, RTX 30xx</td>
+    </tr>
+    <tr class="even">
+    <td>cu102</td>
+    <td>&gt;= 440.33</td>
+    <td>GTX 10xx, RTX 20xx</td>
+    </tr>
+    <tr class="odd">
+    <td>cpu</td>
+    <td>N/A</td>
+    <td>N/A</td>
+    </tr>
+    </tbody>
+    </table></li>
+
 - Install `pybind11`:
 
 ```bash
@@ -28,5 +72,3 @@ pip install pybind11
 ```bash
 pip install -e .
 ```
-
-

--- a/libai/engine/default.py
+++ b/libai/engine/default.py
@@ -547,7 +547,7 @@ class DefaultTrainer(TrainerBase):
         model = build_model(cfg.model)
         logger = logging.getLogger(__name__)
         logger.info("Model:\n{}".format(model))
-        model.apply(dist.convert_to_distributed_default_setting)
+        model._apply(dist.convert_to_distributed_default_setting)
         return model
 
     @classmethod

--- a/libai/utils/distributed.py
+++ b/libai/utils/distributed.py
@@ -387,18 +387,18 @@ def get_num_nodes():
     return flow.env.get_node_size()
 
 
-def convert_to_distributed_default_setting(module):
+def convert_to_distributed_default_setting(t):
     """
     Helper function to convert all eager local tensor in :attr:`nn.Module` in the model to
     global tensor with data parallelism as default.
     """
-    for _, v in module.state_dict().items():
-        if not v.is_global:
-            module.to_global(
-                sbp=get_nd_sbp([flow.sbp.broadcast, flow.sbp.broadcast]),
-                placement=get_layer_placement(0),
-            )
-            return
+    if not t.is_global:
+        return t.to_global(
+            sbp=get_nd_sbp([flow.sbp.broadcast, flow.sbp.broadcast]),
+            placement=get_layer_placement(0),
+        )
+    else:
+        return t
 
 
 def ttol(tensor, pure_local=False, ranks=None):


### PR DESCRIPTION
- 这个pr要做的:

  -  更改libai下的to_global的方式, 支持model部分替换成libai的layers. 比如可以只使用libai下面的Linear层.  这个Liner层可以用户自己更换模型并行的方式, 其他的代码全部用nn.Module即可, 会默认转换成数据并行.
  - 增加Iinstall的安装建议. 如果要用最新的libai, 会推荐用户安装最新的oneflow
 