### PR TITLE
add loss_func=None into cfg

### DIFF
--- a/configs/common/models/swin/swin_tiny_patch4_window7_224.py
+++ b/configs/common/models/swin/swin_tiny_patch4_window7_224.py
@@ -19,7 +19,6 @@ cfg = dict(
     drop_path_rate=0.2,
     ape=False,
     patch_norm=True,
-    use_checkpoint=False,
     loss_func=None,
 )
 

--- a/configs/common/models/swinv2/swinv2_tiny_patch4_window8_256.py
+++ b/configs/common/models/swinv2/swinv2_tiny_patch4_window8_256.py
@@ -17,8 +17,8 @@ cfg = dict(
     drop_path_rate=0.2,
     ape=False,
     patch_norm=True,
-    use_checkpoint=False,
     pretrained_window_sizes=[0, 0, 0, 0],
+    loss_func=None,
 )
 
 cfg = DictConfig(cfg)

--- a/configs/swinv2_imagenet.py
+++ b/configs/swinv2_imagenet.py
@@ -137,6 +137,5 @@ train.rdma_enabled = True
 train.scheduler.warmup_factor = 0.001
 train.scheduler.alpha = 0.01
 train.scheduler.warmup_method = "linear"
-
 # Set fp16 ON
 train.amp.enabled = True


### PR DESCRIPTION
Add the loss_func=None configuration as required to avoid model import errors.