### PR TITLE
Add loader backward test

### DIFF
--- a/tests/model_utils/test_bert_loader.py
+++ b/tests/model_utils/test_bert_loader.py
@@ -208,10 +208,12 @@ class TestBertLoder(flow.unittest.TestCase):
         # backward
         loss = pooled_output.sum()
         loss.backward()
-        
+
         self.assertTrue(np.allclose(-10725.5088, model.pooler.dense.weight.grad.sum()))
-        self.assertTrue(np.allclose(6.151199e-05, model.embeddings.vocab_embeddings.weight.grad.sum().numpy()))
-    
+        self.assertTrue(
+            np.allclose(6.151199e-05, model.embeddings.vocab_embeddings.weight.grad.sum().numpy())
+        )
+
     @flow.unittest.skip_unless_1n4d()
     def test_bert_loader_with_data_tensor_pipeline_parallel_backward(self):
         # set distributed config
@@ -258,9 +260,11 @@ class TestBertLoder(flow.unittest.TestCase):
         # backward
         loss = pooled_output.sum()
         loss.backward()
-        
+
         self.assertTrue(np.allclose(-10725.5088, model.pooler.dense.weight.grad.sum()))
-        self.assertTrue(np.allclose(6.151199e-05, model.embeddings.vocab_embeddings.weight.grad.sum().numpy()))
+        self.assertTrue(
+            np.allclose(6.151199e-05, model.embeddings.vocab_embeddings.weight.grad.sum().numpy())
+        )
 
 
 if __name__ == "__main__":

--- a/tests/model_utils/test_bert_loader.py
+++ b/tests/model_utils/test_bert_loader.py
@@ -73,7 +73,7 @@ class TestBertLoder(flow.unittest.TestCase):
             shutil.rmtree(TEST_OUTPUT)
 
     @flow.unittest.skip_unless_1n4d()
-    def test_bert_utils_with_data_tensor_parallel(self):
+    def test_bert_loader_with_data_tensor_parallel(self):
         # set distributed config
         dist_cfg = DictConfig(
             dict(
@@ -118,7 +118,7 @@ class TestBertLoder(flow.unittest.TestCase):
         )
 
     @flow.unittest.skip_unless_1n4d()
-    def test_bert_utils_with_data_tensor_pipeline_parallel(self):
+    def test_bert_loader_with_data_tensor_pipeline_parallel(self):
         # set distributed config
         dist_cfg = DictConfig(
             dict(
@@ -163,6 +163,105 @@ class TestBertLoder(flow.unittest.TestCase):
             np.allclose(np.array(-214.9335), last_hidden_state.sum().data.numpy(), 1e-4, 1e-4)
         )
 
+    @flow.unittest.skip_unless_1n4d()
+    def test_bert_loader_with_data_tensor_parallel_backward(self):
+        # set distributed config
+        dist_cfg = DictConfig(
+            dict(
+                data_parallel_size=2,
+                tensor_parallel_size=2,
+                pipeline_parallel_size=1,
+            )
+        )
+        dist.setup_dist_util(dist_cfg)
+
+        # load model
+        load_func = BertLoaderHuggerFace(
+            model=libai.models.BertModel,
+            libai_cfg=libai_cfg,
+            pretrained_model_path=self.pretrained_model_path,
+            bias_gelu_fusion=False,
+            bias_dropout_fusion=False,
+            scale_mask_softmax_fusion=False,
+            apply_query_key_layer_scaling=False,
+            apply_residual_post_layernorm=True,
+            amp_enabled=False,
+            hidden_dropout_prob=0,
+            attention_probs_dropout_prob=0,
+        )
+        model = load_func.load()
+
+        input_ids = flow.tensor(
+            self.input_ids,
+            dtype=flow.long,
+            sbp=dist.get_nd_sbp([flow.sbp.broadcast, flow.sbp.broadcast]),
+            placement=model.embeddings.vocab_embeddings.weight.placement,
+        )
+        mask = flow.tensor(
+            self.mask,
+            dtype=flow.bool,
+            sbp=dist.get_nd_sbp([flow.sbp.broadcast, flow.sbp.broadcast]),
+            placement=model.embeddings.vocab_embeddings.weight.placement,
+        )
+        last_hidden_state, _ = model(input_ids, mask)
+
+        # backward
+        loss = last_hidden_state.sum()
+        loss.backward()
+        
+        self.assertTrue(np.allclose(7.6293945e-06, model.final_layernorm.weight.grad.sum().detach().numpy()))
+        self.assertTrue(np.allclose(3.0517578e-05, model.embeddings.vocab_embeddings.weight.grad.sum().numpy()))
+    
+    @flow.unittest.skip_unless_1n4d()
+    def test_bert_loader_with_data_tensor_pipeline_parallel_backward(self):
+        # set distributed config
+        dist_cfg = DictConfig(
+            dict(
+                data_parallel_size=2,
+                tensor_parallel_size=1,
+                pipeline_parallel_size=2,
+                pipeline_num_layers=12,
+            )
+        )
+        dist.setup_dist_util(dist_cfg)
+
+        # load model
+        load_func = BertLoaderHuggerFace(
+            model=libai.models.BertModel,
+            libai_cfg=libai_cfg,
+            pretrained_model_path=self.pretrained_model_path,
+            bias_gelu_fusion=False,
+            bias_dropout_fusion=False,
+            scale_mask_softmax_fusion=False,
+            apply_query_key_layer_scaling=False,
+            apply_residual_post_layernorm=True,
+            amp_enabled=False,
+            hidden_dropout_prob=0,
+            attention_probs_dropout_prob=0,
+        )
+        model = load_func.load()
+
+        input_ids = flow.tensor(
+            self.input_ids,
+            dtype=flow.long,
+            sbp=dist.get_nd_sbp([flow.sbp.broadcast, flow.sbp.broadcast]),
+            placement=model.embeddings.vocab_embeddings.weight.placement,
+        )
+        mask = flow.tensor(
+            self.mask,
+            dtype=flow.bool,
+            sbp=dist.get_nd_sbp([flow.sbp.broadcast, flow.sbp.broadcast]),
+            placement=model.embeddings.vocab_embeddings.weight.placement,
+        )
+        last_hidden_state, _ = model(input_ids, mask)
+
+        # backward
+        loss = last_hidden_state.sum()
+        loss.backward()
+        
+        self.assertTrue(np.allclose(7.6293945e-06, model.final_layernorm.weight.grad.sum().detach().numpy()))
+        self.assertTrue(np.allclose(3.0517578e-05, model.embeddings.vocab_embeddings.weight.grad.sum().numpy()))
+        
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/model_utils/test_bert_loader.py
+++ b/tests/model_utils/test_bert_loader.py
@@ -203,14 +203,14 @@ class TestBertLoder(flow.unittest.TestCase):
             sbp=dist.get_nd_sbp([flow.sbp.broadcast, flow.sbp.broadcast]),
             placement=model.embeddings.vocab_embeddings.weight.placement,
         )
-        last_hidden_state, _ = model(input_ids, mask)
+        last_hidden_state, pooled_output = model(input_ids, mask)
 
         # backward
-        loss = last_hidden_state.sum()
+        loss = pooled_output.sum()
         loss.backward()
         
-        self.assertTrue(np.allclose(7.6293945e-06, model.final_layernorm.weight.grad.sum().detach().numpy()))
-        self.assertTrue(np.allclose(3.0517578e-05, model.embeddings.vocab_embeddings.weight.grad.sum().numpy()))
+        self.assertTrue(np.allclose(-10725.5088, model.pooler.dense.weight.grad.sum()))
+        self.assertTrue(np.allclose(6.151199e-05, model.embeddings.vocab_embeddings.weight.grad.sum().numpy()))
     
     @flow.unittest.skip_unless_1n4d()
     def test_bert_loader_with_data_tensor_pipeline_parallel_backward(self):
@@ -253,15 +253,15 @@ class TestBertLoder(flow.unittest.TestCase):
             sbp=dist.get_nd_sbp([flow.sbp.broadcast, flow.sbp.broadcast]),
             placement=model.embeddings.vocab_embeddings.weight.placement,
         )
-        last_hidden_state, _ = model(input_ids, mask)
+        last_hidden_state, pooled_output = model(input_ids, mask)
 
         # backward
-        loss = last_hidden_state.sum()
+        loss = pooled_output.sum()
         loss.backward()
         
-        self.assertTrue(np.allclose(7.6293945e-06, model.final_layernorm.weight.grad.sum().detach().numpy()))
-        self.assertTrue(np.allclose(3.0517578e-05, model.embeddings.vocab_embeddings.weight.grad.sum().numpy()))
-        
+        self.assertTrue(np.allclose(-10725.5088, model.pooler.dense.weight.grad.sum()))
+        self.assertTrue(np.allclose(6.151199e-05, model.embeddings.vocab_embeddings.weight.grad.sum().numpy()))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/model_utils/test_gpt_loader.py
+++ b/tests/model_utils/test_gpt_loader.py
@@ -243,7 +243,7 @@ class TestGPT2Loader(flow.unittest.TestCase):
         loss.backward()
         
         self.assertTrue(np.allclose(-24882176., model.transformer.layernorm_f.weight.grad.sum().numpy()))
-        self.assertTrue(np.allclose(3.1779e+08, model.embeddings.token_embeddings.weight.grad.sum().numpy(), 1e-3))
+        self.assertTrue(np.allclose(317785760.0, model.embeddings.token_embeddings.weight.grad.sum().numpy()))
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/model_utils/test_gpt_loader.py
+++ b/tests/model_utils/test_gpt_loader.py
@@ -72,7 +72,7 @@ class TestGPT2Loader(flow.unittest.TestCase):
             shutil.rmtree(TEST_OUTPUT)
 
     @flow.unittest.skip_unless_1n4d()
-    def test_gpt_utils_with_data_tensor_parallel(self):
+    def test_gpt_loader_with_data_tensor_parallel(self):
         # set distributed config
         dist_cfg = DictConfig(
             dict(
@@ -116,7 +116,7 @@ class TestGPT2Loader(flow.unittest.TestCase):
         )
 
     @flow.unittest.skip_unless_1n4d()
-    def test_gpt_utils_with_data_tensor_pipeline_parallel(self):
+    def test_gpt_loader_with_data_tensor_pipeline_parallel(self):
         # set distributed config
         dist_cfg = DictConfig(
             dict(
@@ -159,7 +159,91 @@ class TestGPT2Loader(flow.unittest.TestCase):
                 logits.sum().data.numpy(),
             )
         )
+    
+    @flow.unittest.skip_unless_1n4d()
+    def test_gpt_loader_with_data_tensor_parallel_backward(self):
+        # set distributed config
+        dist_cfg = DictConfig(
+            dict(
+                data_parallel_size=2,
+                tensor_parallel_size=2,
+                pipeline_parallel_size=1,
+            )
+        )
+        dist.setup_dist_util(dist_cfg)
+        
+        # load model
+        load_func = GPT2LoaderHuggerFace(
+            model=libai.models.GPTModel,
+            libai_cfg=libai_cfg,
+            pretrained_model_path=self.pretrained_model_path,
+            bias_gelu_fusion=False,
+            bias_dropout_fusion=False,
+            scale_mask_softmax_fusion=True,
+            apply_query_key_layer_scaling=True,
+            apply_residual_post_layernorm=False,
+            amp_enabled=False,
+            attention_dropout_prob=0,
+            output_dropout_prob=0,
+            embedding_dropout_prob=0,
+        )
+        model = load_func.load()
+        
+        input_ids = flow.tensor(
+            self.input_ids,
+            dtype=flow.long,
+            sbp=dist.get_nd_sbp([flow.sbp.broadcast, flow.sbp.broadcast]),
+            placement=model.embeddings.token_embeddings.weight.placement,
+        )
+        logits = model(input_ids)
+        loss = logits.sum()
+        loss.backward()
+        
+        self.assertTrue(np.allclose(-24882176., model.transformer.layernorm_f.weight.grad.sum().numpy()))
+        self.assertTrue(np.allclose(3.1779e+08, model.embeddings.token_embeddings.weight.grad.sum().numpy(), 1e-3))
 
+    @flow.unittest.skip_unless_1n4d()
+    def test_gpt_loader_with_data_tensor_pipeline_parallel_backward(self):
+        # set distributed config
+        dist_cfg = DictConfig(
+            dict(
+                data_parallel_size=2,
+                tensor_parallel_size=1,
+                pipeline_parallel_size=2,
+                pipeline_num_layers=12,
+            )
+        )
+        dist.setup_dist_util(dist_cfg)
+        
+        # load model
+        load_func = GPT2LoaderHuggerFace(
+            model=libai.models.GPTModel,
+            libai_cfg=libai_cfg,
+            pretrained_model_path=self.pretrained_model_path,
+            bias_gelu_fusion=False,
+            bias_dropout_fusion=False,
+            scale_mask_softmax_fusion=True,
+            apply_query_key_layer_scaling=True,
+            apply_residual_post_layernorm=False,
+            amp_enabled=False,
+            attention_dropout_prob=0,
+            output_dropout_prob=0,
+            embedding_dropout_prob=0,
+        )
+        model = load_func.load()
+        
+        input_ids = flow.tensor(
+            self.input_ids,
+            dtype=flow.long,
+            sbp=dist.get_nd_sbp([flow.sbp.broadcast, flow.sbp.broadcast]),
+            placement=model.embeddings.token_embeddings.weight.placement,
+        )
+        logits = model(input_ids)
+        loss = logits.sum()
+        loss.backward()
+        
+        self.assertTrue(np.allclose(-24882176., model.transformer.layernorm_f.weight.grad.sum().numpy()))
+        self.assertTrue(np.allclose(3.1779e+08, model.embeddings.token_embeddings.weight.grad.sum().numpy(), 1e-3))
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/model_utils/test_gpt_loader.py
+++ b/tests/model_utils/test_gpt_loader.py
@@ -159,7 +159,7 @@ class TestGPT2Loader(flow.unittest.TestCase):
                 logits.sum().data.numpy(),
             )
         )
-    
+
     @flow.unittest.skip_unless_1n4d()
     def test_gpt_loader_with_data_tensor_parallel_backward(self):
         # set distributed config
@@ -171,7 +171,7 @@ class TestGPT2Loader(flow.unittest.TestCase):
             )
         )
         dist.setup_dist_util(dist_cfg)
-        
+
         # load model
         load_func = GPT2LoaderHuggerFace(
             model=libai.models.GPTModel,
@@ -188,7 +188,7 @@ class TestGPT2Loader(flow.unittest.TestCase):
             embedding_dropout_prob=0,
         )
         model = load_func.load()
-        
+
         input_ids = flow.tensor(
             self.input_ids,
             dtype=flow.long,
@@ -198,9 +198,15 @@ class TestGPT2Loader(flow.unittest.TestCase):
         logits = model(input_ids)
         loss = logits.sum()
         loss.backward()
-        
-        self.assertTrue(np.allclose(-24882176., model.transformer.layernorm_f.weight.grad.sum().numpy()))
-        self.assertTrue(np.allclose(3.1779e+08, model.embeddings.token_embeddings.weight.grad.sum().numpy(), 1e-3))
+
+        self.assertTrue(
+            np.allclose(-24882176.0, model.transformer.layernorm_f.weight.grad.sum().numpy())
+        )
+        self.assertTrue(
+            np.allclose(
+                3.1779e08, model.embeddings.token_embeddings.weight.grad.sum().numpy(), 1e-3
+            )
+        )
 
     @flow.unittest.skip_unless_1n4d()
     def test_gpt_loader_with_data_tensor_pipeline_parallel_backward(self):
@@ -214,7 +220,7 @@ class TestGPT2Loader(flow.unittest.TestCase):
             )
         )
         dist.setup_dist_util(dist_cfg)
-        
+
         # load model
         load_func = GPT2LoaderHuggerFace(
             model=libai.models.GPTModel,
@@ -231,7 +237,7 @@ class TestGPT2Loader(flow.unittest.TestCase):
             embedding_dropout_prob=0,
         )
         model = load_func.load()
-        
+
         input_ids = flow.tensor(
             self.input_ids,
             dtype=flow.long,
@@ -241,9 +247,14 @@ class TestGPT2Loader(flow.unittest.TestCase):
         logits = model(input_ids)
         loss = logits.sum()
         loss.backward()
-        
-        self.assertTrue(np.allclose(-24882176., model.transformer.layernorm_f.weight.grad.sum().numpy()))
-        self.assertTrue(np.allclose(317785760.0, model.embeddings.token_embeddings.weight.grad.sum().numpy()))
+
+        self.assertTrue(
+            np.allclose(-24882176.0, model.transformer.layernorm_f.weight.grad.sum().numpy())
+        )
+        self.assertTrue(
+            np.allclose(317785760.0, model.embeddings.token_embeddings.weight.grad.sum().numpy())
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/model_utils/test_roberta_loader.py
+++ b/tests/model_utils/test_roberta_loader.py
@@ -163,6 +163,110 @@ class TestRobertaLoader(flow.unittest.TestCase):
             np.allclose(np.array(341.5831), last_hidden_state.sum().data.numpy(), 1e-4, 1e-4)
         )
 
+    @flow.unittest.skip_unless_1n4d()
+    def test_roberta_utils_with_data_tensor_parallel_backward(self):
+        # set distributed config
+        dist_cfg = DictConfig(
+            dict(
+                data_parallel_size=2,
+                tensor_parallel_size=2,
+                pipeline_parallel_size=1,
+            )
+        )
+        dist.setup_dist_util(dist_cfg)
+
+        # load model
+        load_func = RobertaLoaderHuggerFace(
+            model=libai.models.RobertaModel,
+            libai_cfg=libai_cfg,
+            pretrained_model_path=self.pretrained_model_path,
+            bias_gelu_fusion=False,
+            bias_dropout_fusion=False,
+            scale_mask_softmax_fusion=False,
+            apply_query_key_layer_scaling=False,
+            apply_residual_post_layernorm=True,
+            amp_enabled=False,
+            hidden_dropout_prob=0,
+            attention_probs_dropout_prob=0,
+        )
+        model = load_func.load()
+
+        input_ids = flow.tensor(
+            self.input_ids,
+            dtype=flow.long,
+            sbp=dist.get_nd_sbp([flow.sbp.broadcast, flow.sbp.broadcast]),
+            placement=model.embeddings.vocab_embeddings.weight.placement,
+        )
+        mask = flow.tensor(
+            self.mask,
+            dtype=flow.bool,
+            sbp=dist.get_nd_sbp([flow.sbp.broadcast, flow.sbp.broadcast]),
+            placement=model.embeddings.vocab_embeddings.weight.placement,
+        )
+        last_hidden_state, pooled_output = model(input_ids, mask)
+
+        # backward
+        loss = pooled_output.sum()
+        loss.backward()
+
+        self.assertTrue(np.allclose(33871.89, model.pooler.dense.weight.grad.sum()))
+        self.assertTrue(
+            np.allclose(-7.748604e-07, model.embeddings.vocab_embeddings.weight.grad.sum().numpy())
+        )
+
+    @flow.unittest.skip_unless_1n4d()
+    def test_roberta_utils_with_data_tensor_pipeline_parallel_backward(self):
+        # set distributed config
+        dist_cfg = DictConfig(
+            dict(
+                data_parallel_size=2,
+                tensor_parallel_size=1,
+                pipeline_parallel_size=2,
+                pipeline_num_layers=12,
+            )
+        )
+        dist.setup_dist_util(dist_cfg)
+
+        # load model
+        load_func = RobertaLoaderHuggerFace(
+            model=libai.models.RobertaModel,
+            libai_cfg=libai_cfg,
+            pretrained_model_path=self.pretrained_model_path,
+            bias_gelu_fusion=False,
+            bias_dropout_fusion=False,
+            scale_mask_softmax_fusion=False,
+            apply_query_key_layer_scaling=False,
+            apply_residual_post_layernorm=True,
+            amp_enabled=False,
+            hidden_dropout_prob=0,
+            attention_probs_dropout_prob=0,
+        )
+        model = load_func.load()
+
+        input_ids = flow.tensor(
+            self.input_ids,
+            dtype=flow.long,
+            sbp=dist.get_nd_sbp([flow.sbp.broadcast, flow.sbp.broadcast]),
+            placement=model.embeddings.vocab_embeddings.weight.placement,
+        )
+        mask = flow.tensor(
+            self.mask,
+            dtype=flow.bool,
+            sbp=dist.get_nd_sbp([flow.sbp.broadcast, flow.sbp.broadcast]),
+            placement=model.embeddings.vocab_embeddings.weight.placement,
+        )
+
+        last_hidden_state, pooled_output = model(input_ids, mask)
+
+        # backward
+        loss = pooled_output.sum()
+        loss.backward()
+
+        self.assertTrue(np.allclose(33871.89, model.pooler.dense.weight.grad.sum()))
+        self.assertTrue(
+            np.allclose(-7.748604e-07, model.embeddings.vocab_embeddings.weight.grad.sum().numpy())
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/model_utils/test_swin_loader.py
+++ b/tests/model_utils/test_swin_loader.py
@@ -168,10 +168,10 @@ class TestSwinLoder(flow.unittest.TestCase):
         prediction_scores = model(input_image)["prediction_scores"]
         loss = prediction_scores.sum()
         loss.backward()
-
+        
         self.assertTrue(np.allclose(108775.88, model.head.weight.grad.sum().numpy(), 1e-3))
         self.assertTrue(
-            np.allclose(24.320518, model.patch_embed.norm.weight.grad.sum().numpy(), 1e-3)
+            np.allclose(24.320518, model.patch_embed.norm.weight.grad.sum().numpy(), 1e-2)
         )
 
     @flow.unittest.skip_unless_1n4d()
@@ -210,7 +210,7 @@ class TestSwinLoder(flow.unittest.TestCase):
 
         self.assertTrue(np.allclose(108775.88, model.head.weight.grad.sum().numpy(), 1e-3))
         self.assertTrue(
-            np.allclose(24.320518, model.patch_embed.norm.weight.grad.sum().numpy(), 1e-3)
+            np.allclose(24.320518, model.patch_embed.norm.weight.grad.sum().numpy(), 1e-2)
         )
 
 

--- a/tests/model_utils/test_swin_loader.py
+++ b/tests/model_utils/test_swin_loader.py
@@ -101,9 +101,7 @@ class TestSwinLoder(flow.unittest.TestCase):
 
         prediction_scores = model(input_image)["prediction_scores"]
 
-        self.assertTrue(
-            np.allclose(np.array(80.9373), prediction_scores.sum().data.numpy(), 1e-3)
-        )
+        self.assertTrue(np.allclose(np.array(80.9373), prediction_scores.sum().data.numpy(), 1e-3))
 
     @flow.unittest.skip_unless_1n4d()
     def test_swin_utils_with_data_tensor_pipeline_parallel(self):
@@ -136,9 +134,7 @@ class TestSwinLoder(flow.unittest.TestCase):
 
         prediction_scores = model(input_image)["prediction_scores"]
 
-        self.assertTrue(
-            np.allclose(np.array(80.9373), prediction_scores.sum().data.numpy(), 1e-3)
-        )
+        self.assertTrue(np.allclose(np.array(80.9373), prediction_scores.sum().data.numpy(), 1e-3))
 
     @flow.unittest.skip_unless_1n4d()
     def test_swin_utils_with_data_tensor_parallel_backward(self):
@@ -174,7 +170,9 @@ class TestSwinLoder(flow.unittest.TestCase):
         loss.backward()
 
         self.assertTrue(np.allclose(108775.88, model.head.weight.grad.sum().numpy(), 1e-3))
-        self.assertTrue(np.allclose(24.320518, model.patch_embed.norm.weight.grad.sum().numpy(), 1e-3))
+        self.assertTrue(
+            np.allclose(24.320518, model.patch_embed.norm.weight.grad.sum().numpy(), 1e-3)
+        )
 
     @flow.unittest.skip_unless_1n4d()
     def test_swin_utils_with_data_tensor_pipeline_parallel_backward(self):
@@ -211,7 +209,9 @@ class TestSwinLoder(flow.unittest.TestCase):
         loss.backward()
 
         self.assertTrue(np.allclose(108775.88, model.head.weight.grad.sum().numpy(), 1e-3))
-        self.assertTrue(np.allclose(24.320518, model.patch_embed.norm.weight.grad.sum().numpy(), 1e-3))
+        self.assertTrue(
+            np.allclose(24.320518, model.patch_embed.norm.weight.grad.sum().numpy(), 1e-3)
+        )
 
 
 if __name__ == "__main__":

--- a/tests/model_utils/test_swin_loader.py
+++ b/tests/model_utils/test_swin_loader.py
@@ -102,7 +102,7 @@ class TestSwinLoder(flow.unittest.TestCase):
         prediction_scores = model(input_image)["prediction_scores"]
 
         self.assertTrue(
-            np.allclose(np.array(80.9373), prediction_scores.sum().data.numpy(), 1e-4, 1e-4)
+            np.allclose(np.array(80.9373), prediction_scores.sum().data.numpy(), 1e-3)
         )
 
     @flow.unittest.skip_unless_1n4d()
@@ -137,7 +137,7 @@ class TestSwinLoder(flow.unittest.TestCase):
         prediction_scores = model(input_image)["prediction_scores"]
 
         self.assertTrue(
-            np.allclose(np.array(80.9373), prediction_scores.sum().data.numpy(), 1e-4, 1e-4)
+            np.allclose(np.array(80.9373), prediction_scores.sum().data.numpy(), 1e-3)
         )
 
     @flow.unittest.skip_unless_1n4d()
@@ -173,11 +173,11 @@ class TestSwinLoder(flow.unittest.TestCase):
         loss = prediction_scores.sum()
         loss.backward()
 
-        self.assertTrue(np.allclose(108775.88, model.head.weight.grad.sum().numpy()))
-        self.assertTrue(np.allclose(24.320518, model.patch_embed.norm.weight.grad.sum().numpy()))
+        self.assertTrue(np.allclose(108775.88, model.head.weight.grad.sum().numpy(), 1e-3))
+        self.assertTrue(np.allclose(24.320518, model.patch_embed.norm.weight.grad.sum().numpy(), 1e-3))
 
     @flow.unittest.skip_unless_1n4d()
-    def test_swin_utils_with_data_tensor_pipeline_parallel(self):
+    def test_swin_utils_with_data_tensor_pipeline_parallel_backward(self):
         # set distributed config
         dist_cfg = DictConfig(
             dict(
@@ -210,8 +210,8 @@ class TestSwinLoder(flow.unittest.TestCase):
         loss = prediction_scores.sum()
         loss.backward()
 
-        self.assertTrue(np.allclose(108775.88, model.head.weight.grad.sum().numpy()))
-        self.assertTrue(np.allclose(24.320518, model.patch_embed.norm.weight.grad.sum().numpy()))
+        self.assertTrue(np.allclose(108775.88, model.head.weight.grad.sum().numpy(), 1e-3))
+        self.assertTrue(np.allclose(24.320518, model.patch_embed.norm.weight.grad.sum().numpy(), 1e-3))
 
 
 if __name__ == "__main__":

--- a/tests/model_utils/test_swinv2_loader.py
+++ b/tests/model_utils/test_swinv2_loader.py
@@ -173,8 +173,8 @@ class TestSwinV2Loder(flow.unittest.TestCase):
         loss = prediction_scores.sum()
         loss.backward()
 
-        self.assertTrue(np.allclose(373520.47, model.head.weight.grad.sum().numpy()))
-        self.assertTrue(np.allclose(259.379, model.patch_embed.norm.weight.grad.sum().numpy()))
+        self.assertTrue(np.allclose(373520.47, model.head.weight.grad.sum().numpy(), 1e-3))
+        self.assertTrue(np.allclose(259.379, model.patch_embed.norm.weight.grad.sum().numpy(), 1e-3))
 
     @flow.unittest.skip_unless_1n4d()
     def test_swinv2_utils_with_data_tensor_pipeline_parallel_backward(self):
@@ -210,8 +210,8 @@ class TestSwinV2Loder(flow.unittest.TestCase):
         loss = prediction_scores.sum()
         loss.backward()
 
-        self.assertTrue(np.allclose(373520.47, model.head.weight.grad.sum().numpy()))
-        self.assertTrue(np.allclose(259.379, model.patch_embed.norm.weight.grad.sum().numpy()))
+        self.assertTrue(np.allclose(373520.47, model.head.weight.grad.sum().numpy(), 1e-3))
+        self.assertTrue(np.allclose(259.379, model.patch_embed.norm.weight.grad.sum().numpy(), 1e-3))
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/model_utils/test_swinv2_loader.py
+++ b/tests/model_utils/test_swinv2_loader.py
@@ -139,7 +139,7 @@ class TestSwinV2Loder(flow.unittest.TestCase):
         self.assertTrue(
             np.allclose(np.array(221.7827), prediction_scores.sum().data.numpy(), 1e-4, 1e-4)
         )
-    
+
     @flow.unittest.skip_unless_1n4d()
     def test_swinv2_utils_with_data_tensor_parallel_backward(self):
         # set distributed config
@@ -158,7 +158,7 @@ class TestSwinV2Loder(flow.unittest.TestCase):
             libai_cfg=libai_cfg,
             pretrained_model_path=self.pretrained_model_path,
             drop_rate=0,
-            drop_path_rate=0
+            drop_path_rate=0,
         )
         model = load_func.load()
 
@@ -174,7 +174,9 @@ class TestSwinV2Loder(flow.unittest.TestCase):
         loss.backward()
 
         self.assertTrue(np.allclose(373520.47, model.head.weight.grad.sum().numpy(), 1e-3))
-        self.assertTrue(np.allclose(259.379, model.patch_embed.norm.weight.grad.sum().numpy(), 1e-3))
+        self.assertTrue(
+            np.allclose(259.379, model.patch_embed.norm.weight.grad.sum().numpy(), 1e-3)
+        )
 
     @flow.unittest.skip_unless_1n4d()
     def test_swinv2_utils_with_data_tensor_pipeline_parallel_backward(self):
@@ -195,7 +197,7 @@ class TestSwinV2Loder(flow.unittest.TestCase):
             libai_cfg=libai_cfg,
             pretrained_model_path=self.pretrained_model_path,
             drop_rate=0,
-            drop_path_rate=0
+            drop_path_rate=0,
         )
         model = load_func.load()
 
@@ -211,7 +213,10 @@ class TestSwinV2Loder(flow.unittest.TestCase):
         loss.backward()
 
         self.assertTrue(np.allclose(373520.47, model.head.weight.grad.sum().numpy(), 1e-3))
-        self.assertTrue(np.allclose(259.379, model.patch_embed.norm.weight.grad.sum().numpy(), 1e-3))
+        self.assertTrue(
+            np.allclose(259.379, model.patch_embed.norm.weight.grad.sum().numpy(), 1e-3)
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/model_utils/test_vit_loader.py
+++ b/tests/model_utils/test_vit_loader.py
@@ -139,7 +139,7 @@ class TestViTLoder(flow.unittest.TestCase):
         self.assertTrue(
             np.allclose(np.array(3.1374), prediction_scores.sum().data.numpy(), 1e-4, 1e-4)
         )
-        
+
     @flow.unittest.skip_unless_1n4d()
     def test_vit_utils_with_data_tensor_parallel_backward(self):
         # set distributed config
@@ -157,8 +157,8 @@ class TestViTLoder(flow.unittest.TestCase):
             model=libai.models.VisionTransformer,
             libai_cfg=libai_cfg,
             pretrained_model_path=self.pretrained_model_path,
-            drop_rate=0, 
-            attn_drop_rate=0, 
+            drop_rate=0,
+            attn_drop_rate=0,
             drop_path_rate=0,
         )
         model = load_func.load()
@@ -194,8 +194,8 @@ class TestViTLoder(flow.unittest.TestCase):
             model=libai.models.VisionTransformer,
             libai_cfg=libai_cfg,
             pretrained_model_path=self.pretrained_model_path,
-            drop_rate=0, 
-            attn_drop_rate=0, 
+            drop_rate=0,
+            attn_drop_rate=0,
             drop_path_rate=0,
         )
         model = load_func.load()


### PR DESCRIPTION
- 给 model loader 添加了后向对齐的单测，现在libai中模型前向后向的对齐已经完成（bert、roberta进行backward后每次grad会发生变化，暂时没排查）
- 可能是30系列的卡的特殊性，np.allclose(v1,v2)的精度略比其他的卡差，个别模型relative tolerance只能做到1e-3，A100与20系列全部可以到1e-4