### PR TITLE
Add black identity before reduce sum in T5 Loss

### DIFF
--- a/libai/models/t5_model.py
+++ b/libai/models/t5_model.py
@@ -356,6 +356,8 @@ class T5Loss(flow.nn.Module):
         denominator = loss_mask.sum().to_global(
             sbp=dist.get_nd_sbp([flow.sbp.broadcast, flow.sbp.broadcast])
         )
+        lm_loss = flow._C.amp_white_identity(lm_loss)
+        lm_loss = flow._C.amp_black_identity(lm_loss)
         masked_lm_loss = flow.sum(lm_loss.view(-1) * loss_mask.view(-1)) / denominator
         masked_lm_loss = masked_lm_loss.to_global(
             sbp=dist.get_nd_sbp([flow.sbp.partial_sum, flow.sbp.broadcast])


### PR DESCRIPTION
相关链接：https://github.com/Oneflow-Inc/OneTeam/issues/1700#issuecomment-1254492536
