### PR TITLE
Refine mt5

### DIFF
--- a/projects/MT5/layers/attention_layer.py
+++ b/projects/MT5/layers/attention_layer.py
@@ -217,8 +217,8 @@ class MultiheadAttention(nn.Module):
                 position_bias = position_bias[:, :, -hidden_states.size(1) :, :]
 
             position_bias = position_bias + (1 - attention_mask) * -1000
+            position_bias = position_bias.to_global(placement=attention_scores.placement)
 
-        position_bias = position_bias.to_global(placement=attention_scores.placement)
         attention_scores = attention_scores + position_bias
 
         if attention_mask is not None:

--- a/projects/T5/models/attention.py
+++ b/projects/T5/models/attention.py
@@ -224,8 +224,8 @@ class MultiheadAttention(nn.Module):
                 position_bias = position_bias[:, :, -hidden_states.size(1) :, :]
 
             position_bias = position_bias + (1 - attention_mask) * -1000
-
-        position_bias = position_bias.to_global(placement=attention_scores.placement)
+            position_bias = position_bias.to_global(placement=attention_scores.placement)
+        
         attention_scores = attention_scores + position_bias
 
         # [S(0), S(1)] x [S(0), B] = [S(0), S(1)]

--- a/projects/T5/models/attention.py
+++ b/projects/T5/models/attention.py
@@ -225,7 +225,7 @@ class MultiheadAttention(nn.Module):
 
             position_bias = position_bias + (1 - attention_mask) * -1000
             position_bias = position_bias.to_global(placement=attention_scores.placement)
-        
+
         attention_scores = attention_scores + position_bias
 
         # [S(0), S(1)] x [S(0), B] = [S(0), S(1)]


### PR DESCRIPTION
https://github.com/Oneflow-Inc/libai/issues/406#issuecomment-1292151939
> [上文](https://github.com/Oneflow-Inc/libai/issues/406#issuecomment-1292025986)中说的 SelfAttention 中的未知 SendRecv 是必要的，它在代码[这里](https://github.com/Oneflow-Inc/libai/blob/e9ca4087cb35b3ad268534ee60456db689e36063/projects/T5/models/attention.py#L228)，megatron 这里没有的原因是算法不一样，megatron 里面的 t5 没有这个 position_bias。
> 
> position_bias 这里 position_bias (S(0), B) 要与 attention_scores (S(0), S(1)) 做计算，需要做一个 (S(0), B) -> (S(0), S(1))，目前 2d SBP 里面是用 SendRecv 实现的，但可以用 SameDim0AllScatter 来实现（没有通信开销）。
> 
> 但上述 (S(0), B) -> (S(0), S(1)) 的转换不用每一层 layer 都做，因为 position_bias 是在 layer 0 通过 [compute_bias](https://github.com/Oneflow-Inc/libai/blob/e9ca4087cb35b3ad268534ee60456db689e36063/projects/T5/models/attention.py#L219) 计算出来的，后面的所有 layer 使用的都是 layer 0 的 position_bias，所以该转换只需要做一次。而 position_bias 在与 attention_scores 相加之前，需要先与 attention_mask (S(0), B) 相加（见[这里](https://github.com/Oneflow-Inc/libai/blob/e9ca4087cb35b3ad268534ee60456db689e36063/projects/T5/models/attention.py#L226)），加完之后 position_bias sbp 也变为了 (S(0), B)。
> 
> 我们只需要将 [`position_bias = position_bias.to_global(placement=attention_scores.placement)`](https://github.com/Oneflow-Inc/libai/blob/e9ca4087cb35b3ad268534ee60456db689e36063/projects/T5/models/attention.py#L228) 这行代码移动到前面的 if 作用域之内，[`position_bias = position_bias + (1 - attention_mask) * -1000`](https://github.com/Oneflow-Inc/libai/blob/e9ca4087cb35b3ad268534ee60456db689e36063/projects/T5/models/attention.py#L226) 之后，即可使 (S(0), B) -> (S(0), S(1)) 的转换只做1次。

根据wenxiao的这个refine一下mt5的compute_bias中的to_global位置