### PR TITLE
mainstem -> trunk

### DIFF
--- a/configs/common/models/graph.py
+++ b/configs/common/models/graph.py
@@ -10,7 +10,7 @@ graph = dict(
     auto_parallel=dict(
         enabled=False,
         enable_auto_parallel_ignore_user_sbp_config=False,  # ignore all .to_global() in graph
-        mainstem_algo=True,  # consider overlapping calculate time and transfer time
+        trunk_algo=True,  # consider overlapping calculate time and transfer time
         sbp_collector=False,  # use proxy node when one node transfer to many nodes
     ),
     train_graph=LazyCall(GraphBase)(


### PR DESCRIPTION
This pull request fixes a small typo: 
With the previous branch, an error occurs if turn on the auto parallel
```
omegaconf.errors.ConfigAttributeError: Missing key trunk_algo
    full_key: graph.train_graph.auto_parallel_conf.trunk_algo
    object_type=dict
```