### PR TITLE
add_dist_device_type

### DIFF
--- a/libai/utils/distributed.py
+++ b/libai/utils/distributed.py
@@ -302,7 +302,7 @@ def get_dist_util():
     return _DIST_UTIL
 
 
-def get_layer_placement(layer_idx):
+def get_layer_placement(layer_idx, device_type=None):
     """
     Get ``flow.placement`` object with the initialized distributed environment
     according to the ``layer_idx``.
@@ -313,7 +313,7 @@ def get_layer_placement(layer_idx):
         device_type (str, optional): device type. Defaults to "cuda".
     """
     dist_util = get_dist_util()
-    device_type = dist_util.device_type
+    device_type = dist_util.device_type if device_type is None else device_type
     if not flow.cuda.is_available() and device_type == "cuda":
         device_type = "cpu"
     return flow.placement(

--- a/libai/utils/distributed.py
+++ b/libai/utils/distributed.py
@@ -405,6 +405,11 @@ def get_num_nodes():
     return flow.env.get_node_size()
 
 
+def set_device_type(device_type):
+    dist_util = get_dist_util()
+    dist_util.set_device_type(device_type)
+
+
 def broadcast_py_object(obj, src: int = 0):
     rank = flow.env.get_rank()
     if src == rank:


### PR DESCRIPTION
这个PR需要解决的: 

- [x] 在dist下面可以一键设置device_type为`cup`或者是`cuda`


设置方式:
```python
from libai.utils import distributed as dist

dist.set_device_type("cpu")
...
dist.set_device_type("cuda")

```

>>> 该pr解决了超大模型权重在单卡无法加载，可以通过设置device让权重在cpu上加载后使用半精度转到单卡上运行