### PR TITLE
Add support for dynamic control flow of auto placement.

### DIFF
--- a/projects/mock_transformers/dist_infer_opt.py
+++ b/projects/mock_transformers/dist_infer_opt.py
@@ -107,12 +107,18 @@ if __name__ == "__main__":
     )
     
     # generate id
-    for i in range(100):
-        with global_mode(True, **placement_sbp_dict):
-            model = init_env.compile_auto_placement(
-                model,
-                input_ids
-            )
-            generated_ids = model.generate(input_ids, max_length=30)
-        out_put_ids = tokenizer.batch_decode(generated_ids, skip_special_tokens=True)
-        print(out_put_ids)
+    # for i in range(100):
+    
+    # generated_ids = model.generate(input_ids, max_length=30)
+    # raise KeyError
+    with global_mode(True, **placement_sbp_dict):
+        compiled_model = init_env.compile_auto_placement(
+            model,
+            input_ids=input_ids, 
+        )
+        # print(model.code) # use this to print the compiled module code
+        generated_ids = compiled_model.run(input_ids)
+        print(generated_ids)
+        # generated_ids = model(input_ids)
+        # out_put_ids = tokenizer.batch_decode(generated_ids, skip_special_tokens=True)
+        # print(generated_ids)


### PR DESCRIPTION
修复之前auto placement不支持dynamic flow的问题。

目前仍然有以下几个点需要注意或以后解决：

1. transformers代码里有许多对于`ones`，`zeros`的调用，但oneflow 0.9.0对它们的实现是调用了`Ones().__call__()`，这样会导致fx自动对`__call__`进行包装从而使其出错。目前oneflow master分支已经修改成了forward，所以onefx暂时没有做处理。目前要跑通需要用到oneflow的master分支。
2. 目前`compile_auto_placement`函数改成返回一个interpreter，在外面则是接收返回值之后调用`run`。之前直接返回GraphModule的方式不行，这可能是一个BUG，需要以后修复。
3. 原本的测试代码中对auto placement之后的module调用了`generate`函数，这样是不成立的，因为fx就是针对Module的forward进行trace的。这个和2无关，不论是否使用interpreter都是这样。这个可能可以实现，但是肯定会需要自己指定要trace的函数名，这部分后续需要再讨论一下。
4. 在调用`compile_auto_placement`的时候，不用指定concrere_args，但是有一个约定就是如果模型实际运行的时候会指定某个参数，那就需要对这个参数以keyword arg的形式传入`compile_auto_placement`。这个方式后续可以讨论修改一下。
5. onefx也做出了少量必要的修改，这边的onefx版本应该升级到0.2.1（现在还没完成发版），完成后我会slack上面说一声。