### PR TITLE
Fix RTD docs release

### DIFF
--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -1,0 +1,17 @@
+name: Document Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  API_Document_Release:
+    name: API Document Release
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Syncing the webhook
+      env:
+        LIBAI_READTHEDOCS_TOKEN: ${{ secrets.LIBAI_READTHEDOCS_TOKEN }}
+      run: |
+        curl -X POST -d "branches=main" -d "token=${LIBAI_READTHEDOCS_TOKEN}"  https://readthedocs.org/api/v2/webhook/libai/190825/

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.7"
+    python: "3.8"
     # You can also specify other tool versions:
     # nodejs: "16"
     # rust: "1.55"


### PR DESCRIPTION
## This PR is done:

- [x] Add libai request workflow for RTD doc webhook.

libai 的 RTD project 地址：https://readthedocs.org/projects/libai/ 。

已经通过 github 邀请 @CPFLAME 和 @doombeaker 到维护权限。

可以看构建记录和版本管理：
![image](https://user-images.githubusercontent.com/54010254/231968350-226e7a06-efe5-4f20-abd9-6045b196953f.png)

