### PR TITLE
set tensorboardX<=2.5.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,5 +24,5 @@ flake8==3.8.1
 isort==5.10.1
 black==21.4b2
 autoflake
-tensorboardX
+tensorboardX<=2.5.1
 pytest


### PR DESCRIPTION
tensorboardX 2.6使用的protobuf版本(>4.22.3)与oneflow要求版本(<4.0,>=3.9.2)冲突