### PR TITLE
set tensorboardX<=2.5.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -133,7 +133,7 @@ if __name__ == "__main__":
             "isort==5.10.1",
             "black==21.4b ",
             "autoflake",
-            "tensorboardX",
+            "tensorboardX<=2.5.1",
             "pytest",
         ],
         packages=find_packages(),


### PR DESCRIPTION
tensorboardX 2.6使用的protobuf版本(>4.22.3)与oneflow要求版本(<4.0,>=3.9.2)冲突