### PR TITLE
fix llama and test llama2

### DIFF
--- a/projects/mock_transformers/dist_infer_gpt.py
+++ b/projects/mock_transformers/dist_infer_gpt.py
@@ -126,8 +126,15 @@ if __name__ == "__main__":
     )
     dist.setup_dist_util(parallel_config)
 
+    placement_sbp_dict = dict(
+        placement=flow.env.all_device_placement("cuda"),
+        sbp=flow.sbp.broadcast,
+    )
+
     # initial and load model
-    model = AutoModelForCausalLM.from_pretrained("gpt2", torch_dtype=flow.float16)
+    with global_mode(True, **placement_sbp_dict):
+        model = AutoModelForCausalLM.from_pretrained("gpt2", torch_dtype=flow.float16)
+
     # set model to cuda
     dist.set_device_type("cuda")
     model._apply(dist.convert_to_distributed_default_setting)
@@ -144,10 +151,6 @@ if __name__ == "__main__":
     )
 
     # generate id
-    placement_sbp_dict = dict(
-        placement=flow.env.all_device_placement("cuda"),
-        sbp=flow.sbp.broadcast,
-    )
     with global_mode(True, **placement_sbp_dict):
         generated_ids = model.generate(input_ids, max_length=30)
     out_put_ids = tokenizer.batch_decode(generated_ids, skip_special_tokens=True)

--- a/projects/mock_transformers/dist_infer_llama.py
+++ b/projects/mock_transformers/dist_infer_llama.py
@@ -105,7 +105,9 @@ if __name__ == "__main__":
 
     # initial and load model
     with global_mode(True, **placement_sbp_dict):
-        model = AutoModelForCausalLM.from_pretrained("meta-llama/Llama-2-7b", torch_dtype=flow.float16)
+        model = AutoModelForCausalLM.from_pretrained(
+            "meta-llama/Llama-2-7b", torch_dtype=flow.float16
+        )
 
     # set model to cuda
     dist.set_device_type("cuda")

--- a/projects/mock_transformers/dist_infer_llama.py
+++ b/projects/mock_transformers/dist_infer_llama.py
@@ -68,10 +68,10 @@ temp_class = modeling_llama.LlamaMLP
 
 
 class LiBaiLlamaMLP(temp_class):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        hidden_size = kwargs["hidden_size"]
-        intermediate_size = kwargs["intermediate_size"]
+    def __init__(self, config):
+        super().__init__(config)
+        hidden_size = config.hidden_size
+        intermediate_size = config.intermediate_size
         self.gate_proj = Linear(
             hidden_size, intermediate_size, bias=False, parallel="col", dtype=flow.float16
         )
@@ -86,6 +86,8 @@ class LiBaiLlamaMLP(temp_class):
 modeling_llama.LlamaMLP = LiBaiLlamaMLP
 
 if __name__ == "__main__":
+    model_path = "/data/model_ckpt/LinkSoul_Chinese-Llama-2-7b"
+
     # set dist config
     parallel_config = DictConfig(
         dict(
@@ -100,13 +102,13 @@ if __name__ == "__main__":
 
     # initial and load model
     model = AutoModelForCausalLM.from_pretrained(
-        "decapoda-research/llama-13b-hf", torch_dtype=flow.float16
+        model_path, torch_dtype=flow.float16
     )
     # set model to cuda
     dist.set_device_type("cuda")
     model._apply(dist.convert_to_distributed_default_setting)
     # initial tokenizer
-    tokenizer = AutoTokenizer.from_pretrained("decapoda-research/llama-13b-hf", use_fast=False)
+    tokenizer = AutoTokenizer.from_pretrained(model_path, use_fast=False)
 
     # get input_ids
     prompt = "Hello, I'm am conscious and"

--- a/projects/mock_transformers/dist_infer_llama.py
+++ b/projects/mock_transformers/dist_infer_llama.py
@@ -86,8 +86,6 @@ class LiBaiLlamaMLP(temp_class):
 modeling_llama.LlamaMLP = LiBaiLlamaMLP
 
 if __name__ == "__main__":
-    model_path = "/data/model_ckpt/LinkSoul_Chinese-Llama-2-7b"
-
     # set dist config
     parallel_config = DictConfig(
         dict(
@@ -107,13 +105,13 @@ if __name__ == "__main__":
 
     # initial and load model
     with global_mode(True, **placement_sbp_dict):
-        model = AutoModelForCausalLM.from_pretrained(model_path, torch_dtype=flow.float16)
+        model = AutoModelForCausalLM.from_pretrained("meta-llama/Llama-2-7b", torch_dtype=flow.float16)
 
     # set model to cuda
     dist.set_device_type("cuda")
     model._apply(dist.convert_to_distributed_default_setting)
     # initial tokenizer
-    tokenizer = AutoTokenizer.from_pretrained(model_path, use_fast=False)
+    tokenizer = AutoTokenizer.from_pretrained("meta-llama/Llama-2-7b", use_fast=False)
 
     # get input_ids
     prompt = "Hello, I'm am conscious and"


### PR DESCRIPTION
oneflow中需要支持一下pytorch中的[【tensor.storage】](https://pytorch.org/docs/stable/generated/torch.Tensor.storage.html?highlight=storage)：https://github.com/Oneflow-Inc/oneflow/pull/10311

报错：AttributeError: 'Parameter' object has no attribute 'storage'

报错原因，mock的方式运行llama2推理用到transformers，transformers库中在这个pr：[【Support shared tensors】](https://github.com/huggingface/transformers/pull/23871)中更新了`id_tensor_storage`，用来优化checkpoint中共享的tensor重复占用空间。