### PR TITLE
fix some typo: docs/source/tutorials/basics/

### DIFF
--- a/docs/source/tutorials/basics/Config_System.md
+++ b/docs/source/tutorials/basics/Config_System.md
@@ -220,7 +220,7 @@ train = dict(
     seed=1234,
 )
 ```
-**Note:** ``warmup_ratio`` is the ratio of warmup iterations of the total training iterations, and the real ``warmup iterations`` will be calculated by ``wramup_ratio * train_iter`` automatically.
+**Note:** ``warmup_ratio`` is the ratio of warmup iterations of the total training iterations, and the real ``warmup iterations`` will be calculated by ``warmup_ratio * train_iter`` automatically.
 
 **Example:** If you need to train 300 epochs with 5 warmup epochs, update the config as follows:
 ```python

--- a/docs/source/tutorials/basics/Distributed_Configuration.md
+++ b/docs/source/tutorials/basics/Distributed_Configuration.md
@@ -140,7 +140,7 @@ And the `data_parallel_size` will be automatically set to `(8 / (2 * 2)) = 2`
 #### **Set `custom_pipeline_stage_id` for Load Balance**
 In most cases, the transformer layers of common models have the same computational overhead, so there is no need to set `custom_pipeline_stage_id`.
 
-But when transformer layers have unbalanced computational overhead, you can set `custom_pipeline_stage_id` for manually balance the compuation between stages in pipeline_parallelism
+But when transformer layers have unbalanced computational overhead, you can set `custom_pipeline_stage_id` for manually balance the computation between stages in pipeline_parallelism
 
 For example:
 ```python

--- a/docs/source/tutorials/basics/Load_and_Save_Checkpoint.md
+++ b/docs/source/tutorials/basics/Load_and_Save_Checkpoint.md
@@ -49,4 +49,4 @@ checkpointer = Checkpointer(model, save_dir="output/")
 checkpointer.save("model_999")  # save to output/model_999
 ```
 
-You can also save other informations (e.g. `optim`, `scheduler`) other than model weights by using `checkpointer`. See [libai.utils.checkpoint](https://libai.readthedocs.io/en/latest/modules/libai.utils.html#module-libai.utils.checkpoint) for more details.
+You can also save other information's (e.g. `optim`, `scheduler`) other than model weights by using `checkpointer`. See [libai.utils.checkpoint](https://libai.readthedocs.io/en/latest/modules/libai.utils.html#module-libai.utils.checkpoint) for more details.

--- a/docs/source/tutorials/basics/Train_and_Eval_Command_Line.md
+++ b/docs/source/tutorials/basics/Train_and_Eval_Command_Line.md
@@ -49,7 +49,7 @@ train.evaluation.enabled=False   # set no evaluation
 
 To resume training, set `--resume` in the command line, and set `train.output_dir` in your `config.py` or in the command line
 
-For example, if your training is interrupted unexpectly, and your lastest model path is `output/demo/model_0000019/`, then set `train.output_dir=output/demo` to resume trainig:
+For example, if your training is interrupted unexpectedly, and your latest model path is `output/demo/model_0000019/`, then set `train.output_dir=output/demo` to resume training:
 
 ```shell
 bash tools/train.sh \

--- a/docs/source/tutorials/basics/Training.md
+++ b/docs/source/tutorials/basics/Training.md
@@ -92,7 +92,7 @@ Using ``trainer & hook`` system means there will always be some non-standard beh
 
 You can customize your own hooks for some extra tasks during training.
 
-[HookBase](https://github.com/Oneflow-Inc/libai/blob/ffe5ca0e46544d1cbb4fbe88d9185f96c0dc2c95/libai/engine/trainer.py#L28) in `libai/engine/trainer.py` provides a standard behavior for you to use hook. You can overwirte its function according to your own needs. Please refer to [libai/engine/hooks.py](https://github.com/Oneflow-Inc/libai/blob/main/libai/engine/hooks.py) for more details.
+[HookBase](https://github.com/Oneflow-Inc/libai/blob/ffe5ca0e46544d1cbb4fbe88d9185f96c0dc2c95/libai/engine/trainer.py#L28) in `libai/engine/trainer.py` provides a standard behavior for you to use hook. You can overwrite its function according to your own needs. Please refer to [libai/engine/hooks.py](https://github.com/Oneflow-Inc/libai/blob/main/libai/engine/hooks.py) for more details.
 ```python 
 class HookBase:
     def before_train(self):


### PR DESCRIPTION
fix some typo: docs/source/tutorials/basics/
        modified:   docs/source/tutorials/basics/Config_System.md
        modified:   docs/source/tutorials/basics/Distributed_Configuration.md
        modified:   docs/source/tutorials/basics/Load_and_Save_Checkpoint.md
        modified:   docs/source/tutorials/basics/Train_and_Eval_Command_Line.md
        modified:   docs/source/tutorials/basics/Training.md
