### PR TITLE
feat: enable `ModelLoaderHuggerFace` to support loading models in fp16 for inference

### DIFF
--- a/libai/inference/basic.py
+++ b/libai/inference/basic.py
@@ -82,6 +82,9 @@ class BasePipeline(metaclass=ABCMeta):
         self.model._apply(dist.convert_to_distributed_default_setting)
         self.model = self.model.eval()
 
+        # Release unused memory from the device cache after loading the model
+        flow.cuda.empty_cache()
+
         # initial tokenizer
         if dist.is_main_process():
             self.tokenizer = self.build_tokenizer(self.cfg)

--- a/projects/ChatGLM/chatglm.py
+++ b/projects/ChatGLM/chatglm.py
@@ -180,7 +180,8 @@ class CoreAttention(flow.nn.Module):
     def forward(self, query_layer, key_layer, value_layer, attention_mask=None):
         # query_layer: [sq, b, np, hn] -[premute]-> [batch_size, head_num, seq_len, hidden_size]
         query_layer, key_layer, value_layer = [
-            k.permute(1, 2, 0, 3) for k in [query_layer, key_layer, value_layer]
+            # k.permute(1, 2, 0, 3) for k in [query_layer, key_layer, value_layer]
+            k.transpose(1, 2).transpose(0, 2) for k in [query_layer, key_layer, value_layer]
         ]
         if attention_mask is None and query_layer.shape[2] == key_layer.shape[2]:
             context_layer = self.scaled_dot_product_attention(
@@ -194,7 +195,8 @@ class CoreAttention(flow.nn.Module):
                 query_layer, key_layer, value_layer, attention_mask
             )
 
-        context_layer = context_layer.permute(2, 0, 1, 3)
+        # context_layer = context_layer.permute(2, 0, 1, 3)
+        context_layer = context_layer.transpose(0, 1).transpose(0, 2)
         context_layer = context_layer.flatten(2)
         return context_layer
 
@@ -709,7 +711,8 @@ class ChatGLMModel(ChatGLMPreTrainedModel):
         )
         # seq_len, b, nh, hidden_size
         past_key_values = self.dropout(past_key_values)
-        past_key_values = past_key_values.permute([2, 1, 0, 3, 4]).split(2)
+        # past_key_values = past_key_values.permute([2, 1, 0, 3, 4]).split(2)
+        past_key_values = past_key_values.transpose(0, 2).split(2)
         return past_key_values
 
     def forward(

--- a/projects/ChatGLM/chatglm.py
+++ b/projects/ChatGLM/chatglm.py
@@ -180,8 +180,7 @@ class CoreAttention(flow.nn.Module):
     def forward(self, query_layer, key_layer, value_layer, attention_mask=None):
         # query_layer: [sq, b, np, hn] -[premute]-> [batch_size, head_num, seq_len, hidden_size]
         query_layer, key_layer, value_layer = [
-            # k.permute(1, 2, 0, 3) for k in [query_layer, key_layer, value_layer]
-            k.transpose(1, 2).transpose(0, 2) for k in [query_layer, key_layer, value_layer]
+            k.permute(1, 2, 0, 3) for k in [query_layer, key_layer, value_layer]
         ]
         if attention_mask is None and query_layer.shape[2] == key_layer.shape[2]:
             context_layer = self.scaled_dot_product_attention(
@@ -195,8 +194,7 @@ class CoreAttention(flow.nn.Module):
                 query_layer, key_layer, value_layer, attention_mask
             )
 
-        # context_layer = context_layer.permute(2, 0, 1, 3)
-        context_layer = context_layer.transpose(0, 1).transpose(0, 2)
+        context_layer = context_layer.permute(2, 0, 1, 3)
         context_layer = context_layer.flatten(2)
         return context_layer
 
@@ -711,8 +709,7 @@ class ChatGLMModel(ChatGLMPreTrainedModel):
         )
         # seq_len, b, nh, hidden_size
         past_key_values = self.dropout(past_key_values)
-        # past_key_values = past_key_values.permute([2, 1, 0, 3, 4]).split(2)
-        past_key_values = past_key_values.transpose(0, 2).split(2)
+        past_key_values = past_key_values.permute([2, 1, 0, 3, 4]).split(2)
         return past_key_values
 
     def forward(

--- a/projects/ChatGLM/configs/chatglm_config.py
+++ b/projects/ChatGLM/configs/chatglm_config.py
@@ -40,6 +40,7 @@ cfg = dict(
     use_return_dict=True,
     amp_enabled=True,
     # Inference
+    fp16_inference=False,
     is_encoder_decoder=False,
     max_length=1350,
     min_length=0,

--- a/projects/Llama/configs/llama_config.py
+++ b/projects/Llama/configs/llama_config.py
@@ -24,6 +24,7 @@ cfg = dict(
     scale_mask_softmax_fusion=False,
     amp_enabled=True,
     # Inference
+    fp16_inference=True,
     is_encoder_decoder=False,
     max_length=256,
     min_length=0,


### PR DESCRIPTION
`ModelLoaderHuggerFace` currently only supports reading tensors from a checkpoint and loading them into the model, while keeping the tensor dtype as it is.

This PR adds an `fp16_inference` option, allowing `ModelLoaderHuggerFace` to load fp16 models for fp16 inference.